### PR TITLE
CHEF-1995 Getting around ssh delay's on ec2

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -172,6 +172,10 @@ class Chef
       rescue Errno::ECONNREFUSED
         sleep 2
         false
+      # This happens on EC2 quite often
+      rescue Errno::EHOSTUNREACH
+        sleep 2
+        false
       ensure
         tcp_socket && tcp_socket.close
       end


### PR DESCRIPTION
Dear Opscode,

Quite often when I bootstrap a new into ec2 I get a "No route to host" for a few seconds after EC2 has spawned the new node. Eventually (10s later) things settle down and I can actually ssh into the new node. The problem is that the bootstrap process will have given up since the exception goes all the way up, uncaught. I've patched 0.9.x privately to deal with this kind of issue but I'm sure it could be useful to others. Hence the pull request.

As you can see the change is quite minimal. Let me know if this is agreeable. Thanks. I love chef btw!

Alexis (alq@datadoghq.com)
