### PR TITLE
Test dns_name instead of public_ip_address

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -167,6 +167,9 @@ class Chef
         else
           false
         end
+      rescue SocketError
+        sleep 2
+        false
       rescue Errno::ETIMEDOUT
         false
       rescue Errno::EPERM


### PR DESCRIPTION
From a server running inside EC2, the 'knife ec2 server create' command times out unless you open up port 22 to the public IP address of the server executing 'knife ec2 server create'. This is suboptimal because 1) unless you use an elastic IP address you'll have to continually manage the security group allows for port 22 access and 2) you don't get the benefit of using groups to manage access to security groups. Also, the bootstrap code uses the dns_name (which internal to ec2 resolves to the private ip) so the tcp_test_ssh method should use this as well.
