### PR TITLE
Fix knife ec2 server list to compensate for bad Fog output

### DIFF
--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -70,12 +70,12 @@ class Chef
         ]
         connection.servers.all.each do |server|
           server_list << server.id.to_s
-          server_list << (server.public_ip_address == nil ? "" : server.public_ip_address)
-          server_list << (server.private_ip_address == nil ? "" : server.private_ip_address)
-          server_list << (server.flavor_id == nil ? "" : server.flavor_id)
-          server_list << (server.image_id == nil ? "" : server.image_id)
+          server_list << server.public_ip_address.to_s
+          server_list << server.private_ip_address.to_s
+          server_list << server.flavor_id.to_s
+          server_list << server.image_id.to_s
           server_list << server.groups.join(", ")
-          server_list << (server.state == nil ? "" : server.state)
+          server_list << server.state.to_s
         end
         puts ui.list(server_list, :columns_across, 7)
 


### PR DESCRIPTION
Fix issue where bad output from Fog crashes knife ec2 server list (specifically, we were getting an empty array containing an empty hash for a server's status).  This will print whatever comes back from Fog.
