### PR TITLE
OCD spelling commit :D

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -82,7 +82,7 @@ class Chef
         keys.each do |k|
           pretty_key = k.to_s.gsub(/_/, ' ').gsub(/\w+/){ |w| (w =~ /(ssh)|(aws)/i) ? w.upcase  : w.capitalize }
           if Chef::Config[:knife][k].nil?
-            errors << "You did not provided a valid '#{pretty_key}' value."
+            errors << "You did not provide a valid '#{pretty_key}' value."
           end
         end
 


### PR DESCRIPTION
Should read: "You did not provide a valid '#{pretty_key}' value."
