### PR TITLE
Add --aws-endpoint option to change service endpoint

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -51,6 +51,12 @@ class Chef
             :description => "Your AWS region",
             :default => "us-east-1",
             :proc => Proc.new { |key| Chef::Config[:knife][:region] = key }
+
+          option :endpoint,
+            :long => "--aws-endpoint ENDPOINT",
+            :description => "Service endpoint for AWS EC2 service",
+            :default => nil,
+            :proc => Proc.new { |key| Chef::Config[:knife][:aws_endpoint] = key }
         end
       end
 
@@ -60,7 +66,8 @@ class Chef
             :provider => 'AWS',
             :aws_access_key_id => Chef::Config[:knife][:aws_access_key_id],
             :aws_secret_access_key => Chef::Config[:knife][:aws_secret_access_key],
-            :region => locate_config_value(:region)
+            :region => locate_config_value(:region),
+            :endpoint => Chef::Config[:knife][:aws_endpoint]
           )
         end
       end


### PR DESCRIPTION
This is similar to the EC2_URL environment variable used
by the EC2 API tools.
