### PR TITLE
KNIFE_EC2-51 - AWS returns ENETUNREACH while instance is firing up

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -171,6 +171,10 @@ class Chef
       rescue Errno::EHOSTUNREACH
         sleep 2
         false
+      # This happens on EC2 sometimes
+      rescue Errno::ENETUNREACH
+        sleep 2
+        false
       ensure
         tcp_socket && tcp_socket.close
       end
@@ -196,7 +200,7 @@ class Chef
         server.wait_for { print "."; ready? }
 
         puts("\n")
-        
+
         if vpc_mode?
           msg_pair("Subnet ID", server.subnet_id)
         else
@@ -207,9 +211,9 @@ class Chef
         msg_pair("Private IP Address", server.private_ip_address)
 
         print "\n#{ui.color("Waiting for sshd", :magenta)}"
-        
+
         fqdn = vpc_mode? ? server.private_ip_address : server.dns_name
-        
+
         print(".") until tcp_test_ssh(fqdn) {
           sleep @initial_sleep_delay ||= (vpc_mode? ? 40 : 10)
           puts("done")
@@ -291,7 +295,7 @@ class Chef
           exit 1
         end
       end
-      
+
       def create_server_def
         server_def = {
           :image_id => locate_config_value(:image),
@@ -335,7 +339,7 @@ class Chef
                'Ebs.DeleteOnTermination' => delete_term
              }]
         end
-        
+
         server_def
       end
     end


### PR DESCRIPTION
This is related to CHEF-1995 which covers the EHOSTUNREACH case. This
just adds the same sleep/retry logic for the ENETUNREACH case.
