### PR TITLE
Updating fog version

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  #s.add_dependency "fog", "~> 0.8.2"
   s.add_dependency "fog", "~> 1.3.0"
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
I have been using fog version 1.3.0 with knife-ec2 on 20+ ec2 instances on amazon oregon data center (current version of fog in knife-ec2 does not support oregon data center). I wanted to let you know that this version of fog works well and is extensively tested by me.
