### PR TITLE
Remove hard dependency on Fog-gem

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.add_dependency "fog", "~> 1.3"
+
+  # hard fog dependency removed as this interferes with
+  # using a custom (less ancient) fog version in knife plugins.
+  # instead fog is now dynamically required in ec2_base.rb.
+
+  #s.add_dependency "fog", "~> 1.3"
   s.add_dependency "chef", "~> 0.10"
   s.require_paths = ["lib"]
 end

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -29,6 +29,7 @@ class Chef
         includer.class_eval do
 
           deps do
+            gem 'fog', '~> 1.3'
             require 'fog'
             require 'readline'
             require 'chef/json_compat'


### PR DESCRIPTION
This dependency was a problem when a different knife plugin
requires a different fog-version.

I.e.:
- latest knife-rackspace depends on Fog 0.8.2
- latest knife-ec2 depends on Fog 1.3.1

Both can not be installed at the same time, knife will bail out with (or vice versa):

  can't activate fog-0.8.2, already activated fog-1.3.1

The drawback of this patch is that users will have to manually install the required fog-version in order to use the functionality. However this seems like a small price to pay for getting out of inter-dependency hell.

Most importantly: We can now use any fog version in our own knife-plugins and are no longer at the mercy of whatever ancient version knife-rackspace and knife-ec2 dictate.

See also: https://github.com/opscode/knife-rackspace/pull/21 (same pull-request on knife-rackspace gem)
