### PR TITLE
add address sub-commands for allocating, assocating, disassocating, list...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -63,6 +63,26 @@ Outputs a list of all servers in the currently configured AWS account.  <b>PLEAS
 
 Generates instance metadata in meant to be used with Opscode's custom AMIs. This will read your knife configuration <tt>~/.chef/knife.rb</tt> for the validation certificate and Chef server URL to use and output in JSON format. The subcommand also accepts a list of roles/recipes that will be in the node's initial run list.
 
+== knife ec2 address allocate
+
+Allocate an elastic ip to the currently configured AWS account.
+
+== knife ec2 address release
+
+Release (deallocate) an elastic ip, deleting it from the currently configured AWS account.
+
+== knife ec2 address associate
+
+Bind an elastic ip to an EC2 instance in the currently configured AWS account.
+
+== knife ec2 address disassociate
+
+Unbind an elastic ip address from an EC2 instance in the currently configured AWS account.
+
+== knife ec2 address list
+
+Show all IP addresses associated with the currently configured AWS account, each together with the instance with which it is bound (if any).
+
 <b>PLEASE NOTE</b> - Using Opscode's custom AMIs reflect an older way of launching instances in EC2 for Chef and should be considered DEPRECATED. Leveraging this plugins's <tt>knife ec2 server create</tt> subcommands with a base AMIs directly from your Linux distribution (ie Ubuntu AMIs from Canonical) is much preferred and more flexible.  Although this subcommand will remain, the Opscode custom AMIs are currently out of date.
 
 In-depth usage instructions can be found on the {Chef Wiki}[http://wiki.opscode.com/display/chef/Amazon+EC2+AMIs+with+Chef].

--- a/lib/chef/knife/ec2_address_allocate.rb
+++ b/lib/chef/knife/ec2_address_allocate.rb
@@ -1,0 +1,40 @@
+#
+# Author:: Alfred Rossi (<alfred@actionverb.com>)
+# Copyright:: Copyright (c) 2012 Action Verb, LLC.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/ec2_base'
+
+class Chef
+  class Knife
+    class Ec2AddressAllocate < Knife
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 address allocate (options)"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+
+        msg_pair('Public IP', connection.allocate_address.body['publicIp'].to_s)
+
+      end
+    end
+  end
+end
+

--- a/lib/chef/knife/ec2_address_associate.rb
+++ b/lib/chef/knife/ec2_address_associate.rb
@@ -1,0 +1,58 @@
+#
+# Author:: Alfred Rossi (<alfred@actionverb.com>)
+# Copyright:: Copyright (c) 2012 Action Verb, LLC.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'chef/knife/ec2_base'
+
+class Chef
+  class Knife
+    class Ec2AddressAssociate < Knife
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 address associate INSTANCE_ID PUBLIC_IP (options)"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+
+        unless @name_args.length == 2
+          show_usage
+          ui.fatal("You must and may only specify both an instance id and public ip")
+          exit 1
+        end
+
+        instance_id, ip = @name_args
+
+        address_set = connection.describe_addresses.body['addressesSet']
+
+        unless address_set.any? {|rec| rec['publicIp'] == ip}
+          ui.fatal("The specified IP, '#{ip}', could not be found.")
+          exit 1
+        end
+
+        unless connection.servers.any? {|server| server.id == instance_id}
+          ui.fatal("The specified instance id, '#{instance_id}', could not be found.")
+          exit 1
+        end
+
+        connection.associate_address(instance_id, ip)
+      end
+    end
+  end
+end
+

--- a/lib/chef/knife/ec2_address_disassociate.rb
+++ b/lib/chef/knife/ec2_address_disassociate.rb
@@ -1,0 +1,53 @@
+#
+# Author:: Alfred Rossi (<alfred@actionverb.com>)
+# Copyright:: Copyright (c) 2012 Action Verb, LLC.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/ec2_base'
+
+class Chef
+  class Knife
+    class Ec2AddressDisassociate < Knife
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 address disassociate IP (options)"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+
+        unless @name_args.length == 1
+          show_usage
+          ui.fatal("You must and may only specify the ip")
+          exit 1
+        end
+
+        ip = @name_args.first
+
+        address_set = connection.describe_addresses.body['addressesSet']
+        unless address_set.any? {|rec| rec['publicIp'] == ip}
+          ui.fatal("The specified IP, '#{ip}', could not be found.")
+          exit 1
+        end
+
+        connection.disassociate_address(ip)
+      end
+    end
+  end
+end
+

--- a/lib/chef/knife/ec2_address_list.rb
+++ b/lib/chef/knife/ec2_address_list.rb
@@ -1,0 +1,57 @@
+#
+# Author:: Alfred Rossi (<alfred@actionverb.com>)
+# Copyright:: Copyright (c) 2012 Action Verb, LLC.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/ec2_base'
+
+class Chef
+  class Knife
+    class Ec2AddressList < Knife
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 address list (options)"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+
+        ips_list = [
+          ui.color('Public IP', :bold),
+          ui.color('Instance ID', :bold),
+          ui.color('Domain', :bold),
+          ui.color('Allocation ID', :bold),
+          ui.color('Association ID', :bold)
+        ]
+
+        connection.describe_addresses.body['addressesSet'].each do |ip|
+          ips_list << ip['publicIp'].to_s
+          ips_list << ip['instanceId'].to_s
+          ips_list << ip['domain'].to_s
+          ips_list << ip['allocationId'].to_s
+          ips_list << ip['associationId'].to_s
+        end
+
+        puts ui.list(ips_list, :uneven_columns_across, 5)
+
+      end
+    end
+  end
+end
+
+

--- a/lib/chef/knife/ec2_address_release.rb
+++ b/lib/chef/knife/ec2_address_release.rb
@@ -1,0 +1,53 @@
+#
+# Author:: Alfred Rossi (<alfred@actionverb.com>)
+# Copyright:: Copyright (c) 2012 Action Verb, LLC.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/ec2_base'
+
+class Chef
+  class Knife
+    class Ec2AddressRelease < Knife
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 address release IP (options)"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+
+        unless @name_args.length == 1
+          show_usage
+          ui.fatal("You must specify the ip")
+          exit 1
+        end
+
+        ip = @name_args.first
+
+        address_set = connection.describe_addresses.body['addressesSet']
+        unless address_set.any? {|rec| rec['publicIp'] == ip}
+          ui.fatal("The specified IP, '#{ip}', could not be found.")
+          exit 1
+        end
+
+        connection.release_address(ip)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
...ing, and releasing elastic ip addresses

This adds a family of subcommands to knife ec2 for command line inspection and manipulation of elastic ip addresses and their associated instance-bindings.
