### PR TITLE
update default availability zone to us-east-1c

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -67,7 +67,7 @@ class Chef
         :short => "-Z ZONE",
         :long => "--availability-zone ZONE",
         :description => "The Availability Zone",
-        :default => "us-east-1b",
+        :default => "us-east-1c",
         :proc => Proc.new { |key| Chef::Config[:knife][:availability_zone] = key }
 
       option :chef_node_name,


### PR DESCRIPTION
when using default 'us-east-1b' availability zone, the following error will be encountered:

ERROR: Fog::Compute::AWS::Error: Unsupported => The requested Availability Zone is currently constrained and we are no longer accepting new customer requests for t1/m1/c1/m2 instance types. Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1d, us-east-1c.
