### PR TITLE
added ability to pass a JSON file as the json_attributes option

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -149,8 +149,14 @@ class Chef
       option :json_attributes,
         :short => "-j JSON",
         :long => "--json-attributes JSON",
-        :description => "A JSON string to be added to the first run of chef-client",
-        :proc => lambda { |o| JSON.parse(o) },
+        :description => "A JSON string or a path to a JSON file to be added to the first run of chef-client",
+        :proc => lambda { |o| 
+                          if File.exists?(o) 
+                              o = File.read(o)
+                          end
+                          
+                          JSON.parse(o) 
+                        },
         :default => {}
 
 


### PR DESCRIPTION
Hi there,

I tried out the new json_attributes option you added recently to the knife-ec2 create server command but while using it I thought it would be nice to pass a json file instead of just a string.

cheers
Simone
