### PR TITLE
[KNIFE_EC2-74] added new node-name-prefix option

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -221,11 +221,7 @@ class Chef
 
         # Always set the Name tag
         unless hashed_tags.keys.include? "Name"
-          if( locate_config_value(:chef_node_name_prefix) )
-            hashed_tags["Name"] = "#{ locate_config_value(:chef_node_name_prefix) }#{ server.id }"
-          else 
-            hashed_tags["Name"] = locate_config_value(:chef_node_name) || server.id
-          end
+          hashed_tags["Name"] = node_name(server)
         end
 
         hashed_tags.each_pair do |key,val|
@@ -327,7 +323,7 @@ class Chef
         bootstrap.config[:ssh_user] = config[:ssh_user]
         bootstrap.config[:ssh_port] = config[:ssh_port]
         bootstrap.config[:identity_file] = config[:identity_file]
-        bootstrap.config[:chef_node_name] = config[:chef_node_name] || server.id
+        bootstrap.config[:chef_node_name] = node_name(server)
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:first_boot_attributes] = config[:json_attributes]
@@ -421,6 +417,14 @@ class Chef
         end
 
         server_def
+      end
+
+      def node_name(server)
+        if( locate_config_value(:chef_node_name_prefix) )
+          return "#{ locate_config_value(:chef_node_name_prefix) }#{ server.id }"
+        else 
+          return locate_config_value(:chef_node_name) || server.id
+        end
       end
     end
   end


### PR DESCRIPTION
When firing up a bunch of ec2 instances, I didn't want to have to think about uniquely naming each one of them, but using just the instance ID as the name tag was too generic. So I added a node-name-prefix option that is prepended to the server id as the name so that you can still use the top level ec2 console to see reasonable server names w/out having to worry about uniqueness yourself.
