### PR TITLE
Fixed where region config value was getting overriden

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -60,7 +60,7 @@ class Chef
             :provider => 'AWS',
             :aws_access_key_id => Chef::Config[:knife][:aws_access_key_id],
             :aws_secret_access_key => Chef::Config[:knife][:aws_secret_access_key],
-            :region => locate_config_value(:region)
+            :region => Chef::Config[:knife][:region],
           )
         end
       end


### PR DESCRIPTION
I'm not exactly sure why 'region' was being fetched via the locate_config_value method, but switching it the normal Chef::Config structure gets things set properly both via the CLI and the knife.rb config.
