### PR TITLE
Show region debug info on initial connection

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -62,6 +62,8 @@ class Chef
             :aws_secret_access_key => Chef::Config[:knife][:aws_secret_access_key],
             :region => locate_config_value(:region)
           )
+          Chef::Log.debug("Using region '#{connection.instance_variable_get(:@region)}'")
+          connection
         end
       end
 

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -32,8 +32,6 @@ class Chef
 
         validate!
 
-        Chef::Log.debug("Fetching server list from region '#{Chef::Config[:knife][:region]}' and availability_zone '#{Chef::Config[:knife][:availability_zone]}'")
-
         server_list = [
           ui.color('Instance ID', :bold),
           ui.color('Public IP', :bold),


### PR DESCRIPTION
Since region info could either come from the default command line arg, a user-passed command line arg, or from the knife.rb, it would be super helpful to have a debug line that shows which region the connection was specified for.
