### PR TITLE
Add the availibility zone to the knife ec2 server listing.

### DIFF
--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -33,6 +33,7 @@ class Chef
         validate!
 
         server_list = [
+          ui.color('Name', :bold),
           ui.color('Instance ID', :bold),
           ui.color('Public IP', :bold),
           ui.color('Private IP', :bold),
@@ -44,6 +45,7 @@ class Chef
           ui.color('State', :bold)
         ]
         connection.servers.all.each do |server|
+          server_list << server.tags["Name"].to_s
           server_list << server.id.to_s
           server_list << server.public_ip_address.to_s
           server_list << server.private_ip_address.to_s
@@ -64,7 +66,7 @@ class Chef
             end
           end
         end
-        puts ui.list(server_list, :uneven_columns_across, 9)
+        puts ui.list(server_list, :uneven_columns_across, 10)
 
       end
     end

--- a/lib/knife-ec2/version.rb
+++ b/lib/knife-ec2/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Ec2
-    VERSION = "0.5.16"
+    VERSION = "0.6.00"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
When deploying a multi-zone scalable architecture
knowing what zones your servers are currently in
is necessary.

Know when knife ec2 server list is ran, the zone is displayed after the
Private IP.
Eg:
    Instance ID  Public IP           Private IP            Zone            Flavor        Image         SSH Key        Security Groups      State  
    i-a999f9cc   107.22.247.27  10.204.215.104  us-east-1a  m1.small  ami-29f41830  administrator  production          running

I also bumped the minor version to 16.
