### PR TITLE
EC2 Image List functionality

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,10 @@ Deletes an existing server in the currently configured AWS account.  <b>PLEASE N
 
 Outputs a list of all servers in the currently configured AWS account.  <b>PLEASE NOTE</b> - this shows all instances associated with the account, some of which may not be currently managed by the Chef server.
 
+== knife ec2 image list
+
+Displays a list of all AMIs owned by the AWS account. If you need to get AWS Marketplace images or Amazon images, it's probably faster to use the AWS EC2 dashboard.
+
 == knife ec2 instance data
 
 Generates instance metadata in meant to be used with Opscode's custom AMIs. This will read your knife configuration <tt>~/.chef/knife.rb</tt> for the validation certificate and Chef server URL to use and output in JSON format. The subcommand also accepts a list of roles/recipes that will be in the node's initial run list.

--- a/Rakefile
+++ b/Rakefile
@@ -18,10 +18,11 @@
 # limitations under the License.
 #
 
+require 'rubygems'
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-# require 'rubygems'
 # require 'rake/gempackagetask'
 require 'rake/rdoctask'
 

--- a/lib/chef/knife/ec2_image_list.rb
+++ b/lib/chef/knife/ec2_image_list.rb
@@ -1,0 +1,30 @@
+require 'chef/knife/ec2_base'
+
+class Chef
+  class Knife
+    class Ec2ImageList < Knife
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 image list (options)"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+
+        image_list = [
+          ui.color('Image', :bold),
+          ui.color('Name', :bold),
+          ui.color('Source', :bold),
+        ]
+        connection.images.all('Owner'=>'self').each do |image|
+            image_list << image.id.to_s
+            image_list << image.name.to_s
+            image_list << image.description.to_s
+        end
+        puts ui.list(image_list, :uneven_columns_across, 3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi, I thought it might be useful to get a list of relevant AMIs your AWS account had lying around. Please feel free to include if you also find it useful.

p.s. - I wrote this on a machine with ruby 1.8 so I had to move and uncomment the "require 'rubygems'" in the Rakefile. You might want to revert that.

-Steve
