### PR TITLE
[OC-4235] 'delay-loading' changes to reduce load-time

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    knife-ec2 (0.5.14)
+    knife-ec2 (0.6.2)
       chef (>= 0.10.10)
-      fog (~> 1.3)
+      fog (~> 1.6)
 
 GEM
   remote: http://rubygems.org/
   specs:
     builder (3.0.0)
-    bunny (0.8.0)
-    chef (10.12.0)
-      bunny (>= 0.6.0)
+    bunny (0.7.9)
+    chef (10.14.4)
+      bunny (>= 0.6.0, < 0.8.0)
       erubis
       highline (>= 1.6.9)
       json (>= 1.4.4, <= 1.6.1)
-      mixlib-authentication (>= 1.1.0)
+      mixlib-authentication (>= 1.3.0)
       mixlib-cli (>= 1.1.0)
       mixlib-config (>= 1.1.2)
       mixlib-log (>= 1.3.0)
@@ -30,10 +30,10 @@ GEM
       yajl-ruby (~> 1.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    excon (0.14.3)
-    fog (1.4.0)
+    excon (0.16.4)
+    fog (1.6.0)
       builder
-      excon (~> 0.14.0)
+      excon (~> 0.14)
       formatador (~> 0.2.0)
       mime-types
       multi_json (~> 1.0)
@@ -42,16 +42,16 @@ GEM
       nokogiri (~> 1.5.0)
       ruby-hmac
     formatador (0.2.3)
-    highline (1.6.13)
+    highline (1.6.15)
     ipaddress (0.8.0)
     json (1.6.1)
     mime-types (1.19)
-    mixlib-authentication (1.1.4)
+    mixlib-authentication (1.3.0)
       mixlib-log
     mixlib-cli (1.2.2)
     mixlib-config (1.1.2)
     mixlib-log (1.4.1)
-    mixlib-shellout (1.0.0)
+    mixlib-shellout (1.1.0)
     moneta (0.6.0)
     multi_json (1.3.6)
     net-scp (1.0.4)
@@ -86,7 +86,7 @@ GEM
       rspec (~> 2.0)
     ruby-hmac (0.4.0)
     systemu (2.5.2)
-    treetop (1.4.10)
+    treetop (1.4.11)
       polyglot
       polyglot (>= 0.3.1)
     uuidtools (2.1.3)

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require 'chef/knife'
+require 'fog'
 
 class Chef
   class Knife
@@ -29,9 +29,10 @@ class Chef
         includer.class_eval do
 
           deps do
-            require 'fog'
             require 'readline'
             require 'chef/json_compat'
+            require 'chef/knife'
+            Chef::Knife.load_deps
           end
 
           option :aws_access_key_id,

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -26,9 +26,6 @@ class Chef
       include Knife::Ec2Base
 
       deps do
-        require 'fog'
-        require 'readline'
-        require 'chef/json_compat'
         require 'chef/knife/bootstrap'
         Chef::Knife::Bootstrap.load_deps
       end


### PR DESCRIPTION
Here are findings, load-time differences before & after code changes.
# knife-core(no-plugins)

```
    real    0m0.744s
    user    0m0.688s
    sys     0m0.052s
```
# knife(with knife-google, knife-hp, knife-ec2, knife-windows, knife-terremark, knife-bluelock, knife-ec2)

```
# Before  changes, 
    real    0m4.360s
    user    0m3.464s
    sys     0m0.280s

# After changes, 
    real    0m1.738s
    user    0m1.640s
    sys     0m0.076s
```

Environment:
1. Chef Version: 10.14.2
2. Ruby Version: 1.9.3p194
3. Gem Version: 1.8.24
