### PR TITLE
[KNIFE-154] Support IAM Instance Profiles

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -91,7 +91,13 @@ class Chef
       end
 
     end
+
+    def iam_name_from_profile(profile)
+      # The IAM profile object only contains the name as part of the arn
+      if profile && profile.key?('arn')
+        name = profile['arn'].split('/')[-1]
+      end
+      name ||= ''
+    end
   end
 end
-
-

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -50,6 +50,10 @@ class Chef
         :description => "The AMI for the server",
         :proc => Proc.new { |i| Chef::Config[:knife][:image] = i }
 
+      option :iam_instance_profile_name,
+        :long => "--iam-profile-name NAME",
+        :description => "The IAM instance role to apply to this instance."
+
       option :security_groups,
         :short => "-G X,Y,Z",
         :long => "--groups X,Y,Z",
@@ -257,6 +261,8 @@ class Chef
         printed_security_group_ids = @server.security_group_ids.join(", ") if @server.security_group_ids
         msg_pair("Security Group Ids", printed_security_group_ids) if vpc_mode? or @server.security_group_ids
 
+        msg_pair("IAM Profile", locate_config_value(:iam_instance_profile_name))
+
         msg_pair("Tags", hashed_tags)
         msg_pair("SSH Key", @server.key_name)
 
@@ -290,6 +296,7 @@ class Chef
         msg_pair("Availability Zone", @server.availability_zone)
         msg_pair("Security Groups", printed_security_groups) unless vpc_mode? or (@server.groups.nil? and @server.security_group_ids)
         msg_pair("Security Group Ids", printed_security_group_ids) if vpc_mode? or @server.security_group_ids
+        msg_pair("IAM Profile", locate_config_value(:iam_instance_profile_name))
         msg_pair("Tags", hashed_tags)
         msg_pair("SSH Key", @server.key_name)
         msg_pair("Root Device Type", @server.root_device_type)
@@ -391,6 +398,7 @@ class Chef
           :availability_zone => locate_config_value(:availability_zone)
         }
         server_def[:subnet_id] = locate_config_value(:subnet_id) if vpc_mode?
+        server_def[:iam_instance_profile_name] = locate_config_value(:iam_instance_profile_name)
 
         if Chef::Config[:knife][:aws_user_data]
           begin

--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -75,6 +75,7 @@ class Chef
             msg_pair("Region", connection.instance_variable_get(:@region))
             msg_pair("Availability Zone", @server.availability_zone)
             msg_pair("Security Groups", @server.groups.join(", "))
+            msg_pair("IAM Profile", iam_name_from_profile(@server.iam_instance_profile))
             msg_pair("SSH Key", @server.key_name)
             msg_pair("Root Device Type", @server.root_device_type)
             msg_pair("Public DNS Name", @server.dns_name)

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -64,6 +64,7 @@ class Chef
             end
           end,
           
+          ui.color('IAM Profile', :bold),
           ui.color('State', :bold)
         ].flatten.compact
         
@@ -89,6 +90,8 @@ class Chef
             end
           end
           
+          server_list << iam_name_from_profile(server.iam_instance_profile)
+
           server_list << begin
             state = server.state.to_s.downcase
             case state

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -48,6 +48,10 @@ describe Chef::Knife::Ec2ServerCreate do
                            :key_name => 'my_ssh_key',
                            :groups => ['group1', 'group2'],
                            :security_group_ids => ['sg-00aa11bb'],
+                           :iam_instance_profile => {
+                             "arn" => "arn:aws:iam::123456789012:instance-profile/iam-test",
+                             "id" => "ABCD1234EFGH5678IJKL9"
+                           },
                            :dns_name => 'ec2-75.101.253.10.compute-1.amazonaws.com',
                            :public_ip_address => '75.101.253.10',
                            :private_dns_name => 'ip-10-251-75-20.ec2.internal',
@@ -269,6 +273,13 @@ describe Chef::Knife::Ec2ServerCreate do
                                                    { "VirtualName" => "ephemeral1", "DeviceName" => "/dev/sdc" },
                                                    { "VirtualName" => "ephemeral2", "DeviceName" => "/dev/sdd" },
                                                    { "VirtualName" => "ephemeral3", "DeviceName" => "/dev/sde" }]
+    end
+
+    it "sets the specified IAM server role" do
+      @knife_ec2_create.config[:iam_instance_profile_name] = ['iam-role']
+      server_def = @knife_ec2_create.create_server_def
+
+      server_def[:iam_instance_profile_name].should == ['iam-role']
     end
   end
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-154

This pull request adds support for IAM Instance Profiles in the following ways:
- ec2 server create gains an option: --iam-profile-name
- ec2 server list gains a column, showing the assigned profile (if any)
- ec2 server delete prints the profile name in the pre-deletion prompt

This pull request also contains an unrelated commit to fix a bug that currently exists on master.
I'm happy to rebase this branch against a fixed master when it is available.
