### PR TITLE
knife always thinks it's running in ec2 when knife-ec2 is installed

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -180,7 +180,6 @@ class Chef
         :proc => Proc.new { |m| Chef::Config[:knife][:aws_user_data] = m },
         :default => nil
 
-      Chef::Config[:knife][:hints] ||= {}
       option :hint,
         :long => "--hint HINT_NAME[=HINT_FILE]",
         :description => "Specify Ohai Hint to be set on the bootstrap target.  Use multiple --hint options to specify multiple hints.",
@@ -226,6 +225,9 @@ class Chef
         validate!
 
         @server = connection.servers.create(create_server_def)
+
+        # Set ec2 hint
+        Chef::Config[:knife][:hints] ||=  {"ec2" => {}}
 
         hashed_tags={}
         tags.map{ |t| key,val=t.split('='); hashed_tags[key]=val} unless tags.nil?


### PR DESCRIPTION
Every time knife runs and knife-ec2 is installed it sets an empty hint for ec2.  This has the side effect of creating an empty ec2.json file in /etc/chef/ohai when using any of the knife/bootstrap/*.erb templates.

Among other potential problems, this causes `looks_like_ec2?` to always return true:

/usr/lib/ruby/gems/1.9.1/gems/ohai-6.14.0/lib/ohai/plugins/ec2.rb:

```
def looks_like_ec2?
  # Try non-blocking connect so we don't "block" if
  # the Xen environment is *not* EC2
  hint?('ec2') || has_ec2_mac? && can_metadata_connect?(EC2_METADATA_ADDR,80)
end
```

The end result being that Chef _always_ blocks (for several minutes) on an EC2 metadata request regardless of the platform used.

My fix initializes the `:hints` hash if it's nil (which I would guess was the original intent) but leaves it empty.
