### PR TITLE
Relax validation function in ec2_base.rb

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -80,7 +80,7 @@ class Chef
 
         keys.each do |k|
           pretty_key = k.to_s.gsub(/_/, ' ').gsub(/\w+/){ |w| (w =~ /(ssh)|(aws)/i) ? w.upcase  : w.capitalize }
-          if Chef::Config[:knife][k].nil?
+          if Chef::Config[:knife][k].nil? and config[k].nil?
             errors << "You did not provide a valid '#{pretty_key}' value."
           end
         end


### PR DESCRIPTION
When invoking the Ec2ServerCreate command from another plugin it isn't possible to just pass in the config like this:

knife_ec2 = Chef::Knife::Ec2ServerCreate.new
knife_ec2.config[:image] = image
knife_ec2.run

...as the validate function only checks if required options are present in the Chef::Config, even
though the code later overrides these in locate_config. 

This change relaxes the validation function to also check whether a required key is in the config object
