### PR TITLE
KNIFE-207 fix

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -227,6 +227,11 @@ class Chef
 
         @server = connection.servers.create(create_server_def)
 
+        # wait for it to be ready to do stuff
+        @server.wait_for { print "."; ready? }
+
+        puts("\n")
+
         hashed_tags={}
         tags.map{ |t| key,val=t.split('='); hashed_tags[key]=val} unless tags.nil?
 
@@ -262,10 +267,6 @@ class Chef
 
         print "\n#{ui.color("Waiting for server", :magenta)}"
 
-        # wait for it to be ready to do stuff
-        @server.wait_for { print "."; ready? }
-
-        puts("\n")
 
         if vpc_mode?
           msg_pair("Subnet ID", @server.subnet_id)


### PR DESCRIPTION
Moving the wait statement up just under the server create so when the instance comes up and the name is attached, the chef run will properly wait for everything to come online before attempting to do anything else.

This is a fix for http://tickets.opscode.com/browse/KNIFE-207
