### PR TITLE
KNIFE-207: wait for the instance before creating tags

### DIFF
--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -100,6 +100,15 @@ describe Chef::Knife::Ec2ServerCreate do
       @knife_ec2_create.run
       @knife_ec2_create.server.should_not == nil
     end
+
+    it "retries if it receives Fog::Compute::AWS::NotFound" do
+      @new_ec2_server.should_receive(:wait_for).and_return(true)
+      @knife_ec2_create.should_receive(:create_tags).and_raise(Fog::Compute::AWS::NotFound)
+      @knife_ec2_create.should_receive(:create_tags).and_return(true)
+      @knife_ec2_create.should_receive(:sleep).and_return(true)
+      @knife_ec2_create.ui.should_receive(:warn).with(/retrying/)
+      @knife_ec2_create.run
+    end
   end
 
   describe "when setting tags" do


### PR DESCRIPTION
The instance needs to exist before Fog acts against it, so this shuffles
around wait_for/ready? and also adds a retry for the edge case.
