### PR TITLE
[KNIFE-240] use chef search to figure out instance id from node name and vice versa

### DIFF
--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -63,6 +63,11 @@ class Chef
       def run
 
         validate!
+        if @name_args.empty? && config[:chef_node_name]
+          ui.info("no instance id is specific, trying to retrieve it from node name")
+          instance_id = guess_instance_id(config[:chef_node_name])
+          @name_args << instance_id unless instance_id.nil?
+        end
 
         @name_args.each do |instance_id|
 
@@ -90,19 +95,44 @@ class Chef
             ui.warn("Deleted server #{@server.id}")
 
             if config[:purge]
-              thing_to_delete = config[:chef_node_name] || instance_id
+              if config[:chef_node_name]
+                thing_to_delete = config[:chef_node_name]
+              else
+                thing_to_delete = guess_node_name(instance_id)
+              end
               destroy_item(Chef::Node, thing_to_delete, "node")
               destroy_item(Chef::ApiClient, thing_to_delete, "client")
             else
               ui.warn("Corresponding node and client for the #{instance_id} server were not deleted and remain registered with the Chef Server")
             end
-
           rescue NoMethodError
             ui.error("Could not locate server '#{instance_id}'.  Please verify it was provisioned in the '#{locate_config_value(:region)}' region.")
           end
         end
       end
 
+      def guess_node_name(instance_id)
+        result = query.search(:node,"ec2_instance_id:#{instance_id}")
+        unless result.first.empty?
+          result.first.first.name
+        else
+          instance_id
+        end
+      end
+
+      def guess_instance_id(name)
+        result = query.search(:node,"name:#{name}")
+        unless result.first.empty?
+          node = result.first.first
+          if node.attribute?('ec2')
+            node['ec2']['instance_id']
+          end
+        end
+      end
+
+      def query
+        @query ||= Chef::Search::Query.new
+      end
     end
   end
 end

--- a/spec/unit/ec2_server_delete_spec.rb
+++ b/spec/unit/ec2_server_delete_spec.rb
@@ -1,0 +1,138 @@
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path('../../spec_helper', __FILE__)
+require 'fog'
+
+
+describe Chef::Knife::Ec2ServerDelete do
+  before do
+  end
+
+  describe "run" do
+    before(:each) do
+      {
+        :image => 'image',
+        :aws_ssh_key_id => 'aws_ssh_key_id',
+        :aws_access_key_id => 'aws_access_key_id',
+        :aws_secret_access_key => 'aws_secret_access_key'
+      }.each do |key, value|
+        Chef::Config[:knife][key] = value
+      end
+
+      @ec2_server_attribs = { :id => 'i-39382318',
+                             :flavor_id => 'm1.small',
+                             :image_id => 'ami-47241231',
+                             :availability_zone => 'us-west-1',
+                             :key_name => 'my_ssh_key',
+                             :groups => ['group1', 'group2'],
+                             :security_group_ids => ['sg-00aa11bb'],
+                             :dns_name => 'ec2-75.101.253.10.compute-1.amazonaws.com',
+                             :public_ip_address => '75.101.253.10',
+                             :private_dns_name => 'ip-10-251-75-20.ec2.internal',
+                             :private_ip_address => '10.251.75.20',
+                             :root_device_type => 'not_ebs' }
+        @knife_ec2_delete = Chef::Knife::Ec2ServerDelete.new
+        @ec2_servers = mock()
+        @knife_ec2_delete.ui.stub(:confirm)
+        @knife_ec2_delete.stub(:msg_pair)
+        @ec2_server = mock(@ec2_server_attribs)
+        @ec2_connection = mock(Fog::Compute::AWS)
+        @ec2_connection.stub!(:servers).and_return(@ec2_servers)
+        @knife_ec2_delete.ui.stub(:warn)
+      end
+
+    it "should invoke validate!" do
+      knife_ec2_delete = Chef::Knife::Ec2ServerDelete.new
+      knife_ec2_delete.should_receive(:validate!)
+      knife_ec2_delete.run
+    end
+
+    it "should use invoke fog api to delete instance if instance id is passed" do
+      @ec2_servers.should_receive(:get).with('foo').and_return(@ec2_server)
+      Fog::Compute::AWS.should_receive(:new).and_return(@ec2_connection)
+      @knife_ec2_delete.name_args = ['foo']
+      @knife_ec2_delete.should_receive(:validate!)
+      @ec2_server.should_receive(:destroy)
+      @knife_ec2_delete.run
+    end
+
+    it "should use node_name to figure out instance id if not specified explicitly" do
+        @ec2_servers.should_receive(:get).with('foo').and_return(@ec2_server)
+        Fog::Compute::AWS.should_receive(:new).and_return(@ec2_connection)
+        @knife_ec2_delete.should_receive(:validate!)
+        @ec2_server.should_receive(:destroy)
+        @knife_ec2_delete.config[:purge] = false
+        @knife_ec2_delete.config[:chef_node_name] = 'baz'
+        mock_node = mock(Chef::Node)
+        mock_node.should_receive(:attribute?).with('ec2').and_return(true)
+        mock_node.should_receive(:[]).with('ec2').and_return('instance_id'=>'foo')
+        mock_search = mock(Chef::Search::Query)
+        mock_search.should_receive(:search).with(:node,"name:baz").and_return([[mock_node],nil,nil])
+        Chef::Search::Query.should_receive(:new).and_return(mock_search)
+        @knife_ec2_delete.name_args = []
+        @knife_ec2_delete.run
+    end
+
+    describe "when --purge is passed" do
+      it "should use the node name if its set" do
+        @ec2_servers.should_receive(:get).with('foo').and_return(@ec2_server)
+        Fog::Compute::AWS.should_receive(:new).and_return(@ec2_connection)
+        @knife_ec2_delete.name_args = ['foo']
+        @knife_ec2_delete.should_receive(:validate!)
+        @ec2_server.should_receive(:destroy)
+        @knife_ec2_delete.config[:purge] = true
+        @knife_ec2_delete.config[:chef_node_name] = 'baz'
+        Chef::Node.should_receive(:load).with('baz').and_return(mock(:destroy=>true))
+        Chef::ApiClient.should_receive(:load).with('baz').and_return(mock(:destroy=>true))
+        @knife_ec2_delete.run
+      end
+
+      it "should search for the node name using the instance id when node name is not specified" do
+        @ec2_servers.should_receive(:get).with('i-foo').and_return(@ec2_server)
+        Fog::Compute::AWS.should_receive(:new).and_return(@ec2_connection)
+        @knife_ec2_delete.name_args = ['i-foo']
+        @knife_ec2_delete.should_receive(:validate!)
+        @ec2_server.should_receive(:destroy)
+        @knife_ec2_delete.config[:purge] = true
+        @knife_ec2_delete.config[:chef_node_name] = nil
+        mock_search = mock(Chef::Search::Query)
+        mock_node = mock(Chef::Node)
+        mock_node.should_receive(:name).and_return("baz")
+        Chef::Node.should_receive(:load).with('baz').and_return(mock(:destroy=>true))
+        Chef::ApiClient.should_receive(:load).with('baz').and_return(mock(:destroy=>true))
+        mock_search.should_receive(:search).with(:node,"ec2_instance_id:i-foo").and_return([[mock_node],nil,nil])
+        Chef::Search::Query.should_receive(:new).and_return(mock_search)
+        @knife_ec2_delete.run
+      end
+
+      it "should use  the instance id if search does not return anything" do
+        @ec2_servers.should_receive(:get).with('i-foo').and_return(@ec2_server)
+        Fog::Compute::AWS.should_receive(:new).and_return(@ec2_connection)
+        @knife_ec2_delete.name_args = ['i-foo']
+        @knife_ec2_delete.should_receive(:validate!)
+        @ec2_server.should_receive(:destroy)
+        @knife_ec2_delete.config[:purge] = true
+        @knife_ec2_delete.config[:chef_node_name] = nil
+        Chef::Node.should_receive(:load).with('i-foo').and_return(mock(:destroy=>true))
+        Chef::ApiClient.should_receive(:load).with('i-foo').and_return(mock(:destroy=>true))
+        mock_search = mock(Chef::Search::Query)
+        mock_search.should_receive(:search).with(:node,"ec2_instance_id:i-foo").and_return([[],nil,nil])
+        Chef::Search::Query.should_receive(:new).and_return(mock_search)
+        @knife_ec2_delete.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-240

it is cumbersome to delete instances using ec2 instance id. this pull request enables the `knife ec2 server delete`  command to fetch ec instance id if only chef_node_name option is passed (i.e.e name_args is empty) and vice versa (i.e.e retrive chef node name when only ec2 instance id is passed along with --purge)
