### PR TITLE
[KNIFE-290] Fix tags output

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -331,6 +331,8 @@ class Chef
           hashed_tags["Name"] = locate_config_value(:chef_node_name) || @server.id
         end
 
+        printed_tags = hashed_tags.map{ |tag, val| "#{tag}: #{val}" }.join(", ")
+
         msg_pair("Instance ID", @server.id)
         msg_pair("Flavor", @server.flavor_id)
         msg_pair("Image", @server.image_id)
@@ -350,7 +352,7 @@ class Chef
         msg_pair("Security Group Ids", printed_security_group_ids) if vpc_mode? or @server.security_group_ids
 
 
-        msg_pair("Tags", hashed_tags)
+        msg_pair("Tags", printed_tags)
         msg_pair("SSH Key", @server.key_name)
 
         print "\n#{ui.color("Waiting for instance", :magenta)}"
@@ -417,7 +419,7 @@ class Chef
         msg_pair("Availability Zone", @server.availability_zone)
         msg_pair("Security Groups", printed_security_groups) unless vpc_mode? or (@server.groups.nil? and @server.security_group_ids)
         msg_pair("Security Group Ids", printed_security_group_ids) if vpc_mode? or @server.security_group_ids
-        msg_pair("Tags", hashed_tags)
+        msg_pair("Tags", printed_tags)
         msg_pair("SSH Key", @server.key_name)
         msg_pair("Root Device Type", @server.root_device_type)
         if @server.root_device_type == "ebs"


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-290

Fix tags output which is currently 'keyvalue' to 'key: value' and comma separated.
