### PR TITLE
[KNIFE-333] Added a bunch more information to the output

### DIFF
--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -160,7 +160,13 @@ class Chef
           end
           
           server_list << server.public_ip_address.to_s
-          server_list << server.private_ip_address.to_s
+
+          if server.subnet_id
+            server_list << "#{server.subnet_id}/#{server.private_ip_address}"
+          else
+            server_list << server.private_ip_address.to_s
+          end
+          
           server_list << ui.color(
                                   server.flavor_id.to_s,
                                   fcolor(server.flavor_id.to_s)


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-333

And made more columns optional.
- Added columns: AZ and VPC
- Made image and key columns optional
- Color-coded instance flavors and AZs
- Display group ids if instance is in a VPC
- Display subnet ids in the private IPs column (where applicable)
