### PR TITLE
Attributes file

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -169,7 +169,7 @@ class Chef
         :short => "-J JSON_FILE",
         :long => "--json-attributes-file FILE",
         :description => "A JSON file with 'normal' attributes to be added to the first run of chef-client",
-        :proc => lambda { |o| JSON.parse(File.read(o))[:normal] }
+        :proc => lambda { |o| attrs = JSON.parse(File.read(o)); attrs["normal"] }
 
       option :subnet_id,
         :short => "-s SUBNET-ID",


### PR DESCRIPTION
We manage some 'snow flake' servers and it's important to specify attributes such as EBS volume ids at create time. I added support for loading attributes from a JSON file.

```
knife ec2 server create --json-attributes-file=nodes/my_node.json
```

The attributes file loader will then pull out "normal" attributes. It could be extended to merge all different attributes or something, but this solved my immediate need.

Feedback? Thoughts?
