### PR TITLE
[KNIFE-337] Add additional sleep and return password value correctly

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -293,6 +293,12 @@ class Chef
             response = connection.get_password_data(@server.id)
             data = File.read(locate_config_value(:identity_file))
             config[:winrm_password] = decrypt_admin_password(response.body["passwordData"], data)
+            # Even though the winrm port is available we need to wait just a bit for the service
+            # to actually come up after the password is generated. In the future we should create
+            # a method to probe winrm to determine readiness.
+            print "\n#{ui.color("Waiting for WinRM service to be available", :magenta)}\n"
+            sleep 100
+            config[:winrm_password]
           else
             ui.error("Cannot find SSH Identity file, required to fetch dynamically generated password")
             exit 1


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-337

This fixes an issue that causes 'knife ec2 server create' to not properly return the password to bootstrap config thus causing the bootstrap to fail after instance creation.

Also, it appears that even though the WinRM port is available when the password is retrieved it takes the WinRM service about a minute to come up after the password is generated. So for now I've added another manual 100 second sleep. In the future there should be a method to probe winrm to really find out availability. Hard coding sleeps feels really brittle but works for now.

With these minor tweaks I can now run the following single command to provision, bootstrap and run a role.

E.G.

``` text
knife ec2 server create -VV \
-I ami-b5bcd2dc \
--flavor=m1.medium \
--groups=quick-start-1 \
--region=us-east-1 \
--ssh-key=mykey-deploy-us-east \
--identity-file=/path/to/.ssh/mykey-deploy-us-east.pem \
--bootstrap-protocol winrm \
--distro=windows-chef-client-msi \
--user-data=/path/to/Development/enable-winrm.ps1 \
--run-list 'role[production-win]' \
--node-name=My_Custom_Node_Name
```
