### PR TITLE
[KNIFE-333] Add VPC data to ec2 server list.

### DIFF
--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -34,15 +34,54 @@ class Chef
         :default => true,
         :description => "Do not display name tag in output"
 
+      option :vpc,
+        :short => "-v",
+        :long => "--vpc",
+        :boolean => true,
+        :default => false,
+        :description => "Show VPC ID"
+
+      option :key,
+        :long => "--no-key",
+        :boolean => true,
+        :default => true,
+        :description => "Disable displaying SSH key"
+
+      option :image,
+        :long => "--no-image",
+        :boolean => true,
+        :default => true,
+        :description => "Disable displaying AMI"
+
       option :tags,
         :short => "-t TAG1,TAG2",
         :long => "--tags TAG1,TAG2",
         :description => "List of tags to output"
 
+      def groups_with_ids(groups)
+        groups.map{|g| 
+          "#{g} (#{@group_id_hash[g]})"
+        }
+      end
+
+      def vpc_with_name(vpc_id)
+        this_vpc = @vpcs.select{|v| v.id == vpc_id }.first
+        if this_vpc.tags["Name"]
+          vpc_name = this_vpc.tags["Name"]
+          "#{vpc_name} (#{vpc_id})"
+        else
+          vpc_id
+        end
+      end
+
       def run
         $stdout.sync = true
 
         validate!
+
+        @group_id_hash = Hash[connection.security_groups.map{|g| 
+          [g.group_id, g.name]
+        }]
 
         server_list = [
           ui.color('Instance ID', :bold),
@@ -54,8 +93,15 @@ class Chef
           ui.color('Public IP', :bold),
           ui.color('Private IP', :bold),
           ui.color('Flavor', :bold),
-          ui.color('Image', :bold),
-          ui.color('SSH Key', :bold),
+
+          if config[:image]
+            ui.color('Image', :bold)
+          end,
+
+          if config[:key]
+            ui.color('SSH Key', :bold)
+          end,
+
           ui.color('Security Groups', :bold),
           
           if config[:tags]
@@ -63,11 +109,19 @@ class Chef
               ui.color("Tag:#{tag_name}", :bold)
             end
           end,
+
+          if config[:vpc]
+            ui.color('VPC', :bold)
+          end,
           
           ui.color('State', :bold)
         ].flatten.compact
         
         output_column_count = server_list.length
+
+        if config[:vpc]
+          @vpcs = connection.vpcs.all
+        end
         
         connection.servers.all.each do |server|
           server_list << server.id.to_s
@@ -77,15 +131,40 @@ class Chef
           end
           
           server_list << server.public_ip_address.to_s
-          server_list << server.private_ip_address.to_s
+
+          if server.subnet_id
+            server_list << "#{server.subnet_id}/#{server.private_ip_address}"
+          else
+            server_list << server.private_ip_address.to_s
+          end
+          
           server_list << server.flavor_id.to_s
-          server_list << server.image_id.to_s
-          server_list << server.key_name.to_s
-          server_list << server.groups.join(", ")
+
+          if config[:image]
+            server_list << server.image_id.to_s
+          end
+
+          if config[:key]
+            server_list << server.key_name.to_s
+          end
+
+          if server.vpc_id
+            server_list << groups_with_ids(server.security_group_ids).join(", ")
+          else
+            server_list << server.groups.join(", ")
+          end
           
           if config[:tags]
             config[:tags].split(",").each do |tag_name|
               server_list << server.tags[tag_name].to_s
+            end
+          end
+
+          if config[:vpc]
+            if server.vpc_id
+              server_list << vpc_with_name(server.vpc_id.to_s)
+            else
+              server_list << "-"
             end
           end
           


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-333

And made more columns optional.

```
Added column: VPC
Made image and key columns optional (so that things would still fit on most screens)
Display group ids if instance is in a VPC
Display subnet ids in the private IPs column (where applicable)
```
