### PR TITLE
[KNIFE-376] Add --no-bootstrap-node option.

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -237,6 +237,12 @@ class Chef
         :short => "-a ATTRIBUTE",
         :description => "The EC2 server attribute to use for SSH connection",
         :default => nil
+        
+      option :bootstrap_node,
+        :long => "--[no-]bootstrap-node",
+        :description => "Bootstrap the node after provisioning the server. Enabled by default.",
+        :boolean => true,
+        :default => true
 
     def tcp_test_winrm(ip_addr, port)
       tcp_socket = TCPSocket.new(ip_addr, port)
@@ -425,10 +431,10 @@ class Chef
               puts("done")
             }
           end
-          bootstrap_for_windows_node(@server,ssh_connect_host).run
+          bootstrap_for_windows_node(@server,ssh_connect_host).run if config[:bootstrap_node]
         else
             wait_for_sshd(ssh_connect_host)
-            bootstrap_for_linux_node(@server,ssh_connect_host).run
+            bootstrap_for_linux_node(@server,ssh_connect_host).run if config[:bootstrap_node]
         end
 
         puts "\n"

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -36,6 +36,7 @@ describe Chef::Knife::Ec2ServerCreate do
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
+    @knife_ec2_create.config[:bootstrap_node] = true
 
     @ec2_connection = double(Fog::Compute::AWS)
     @ec2_connection.stub_chain(:tags).and_return double('create', :create => true)
@@ -84,22 +85,32 @@ describe Chef::Knife::Ec2ServerCreate do
 
       @bootstrap = Chef::Knife::Bootstrap.new
       Chef::Knife::Bootstrap.stub(:new).and_return(@bootstrap)
-      @bootstrap.should_receive(:run)
     end
 
     it "creates an EC2 instance and bootstraps it" do
+      @bootstrap.should_receive(:run)
       @new_ec2_server.should_receive(:wait_for).and_return(true)
       @knife_ec2_create.run
       @knife_ec2_create.server.should_not == nil
     end
 
     it "should never invoke windows bootstrap for linux instance" do
+      @bootstrap.should_receive(:run)
       @new_ec2_server.should_receive(:wait_for).and_return(true)
       @knife_ec2_create.should_not_receive(:bootstrap_for_windows_node)
       @knife_ec2_create.run
     end
+    
+    it "should not bootstrap if --no-bootstrap-node" do
+      @knife_ec2_create.config[:bootstrap_node] = false
+      @new_ec2_server.should_receive(:wait_for).and_return(true)
+      @knife_ec2_create.should_not_receive(:bootstrap_for_linux_node)
+      @bootstrap.should_not_receive(:run)
+      @knife_ec2_create.run
+    end
 
     it "creates an EC2 instance, assigns existing EIP and bootstraps it" do
+      @bootstrap.should_receive(:run)
       @knife_ec2_create.config[:associate_eip] = @eip
 
       @new_ec2_server.stub(:public_ip_address).and_return(@eip)
@@ -111,6 +122,7 @@ describe Chef::Knife::Ec2ServerCreate do
     end
 
     it "retries if it receives Fog::Compute::AWS::NotFound" do
+      @bootstrap.should_receive(:run)
       @new_ec2_server.should_receive(:wait_for).and_return(true)
       @knife_ec2_create.should_receive(:create_tags).and_raise(Fog::Compute::AWS::NotFound)
       @knife_ec2_create.should_receive(:create_tags).and_return(true)
@@ -176,6 +188,14 @@ describe Chef::Knife::Ec2ServerCreate do
       @knife_ec2_create.stub(:bootstrap_for_windows_node).and_return double("bootstrap", :run => true)
       @knife_ec2_create.run
     end
+    
+    it "should not bootstrap if --no-bootstrap-node" do
+      @knife_ec2_create.config[:bootstrap_node] = false
+      @new_ec2_server.should_receive(:wait_for).and_return(true)
+      @knife_ec2_create.should_not_receive(:bootstrap_for_windows_node)
+      @knife_ec2_create.run
+    end
+    
 
     it "waits for EC2 to generate password if not supplied" do
       @knife_ec2_create.config[:bootstrap_protocol] = 'winrm'


### PR DESCRIPTION
When specified, the node is provisioned on EC2, but Knife::Bootstrap is not run.
Useful for provisioning instances via all the normal logic, but then doing some
intermediate step and then running `knife bootstrap` later on.
