### PR TITLE
revert default bootstrap behavior to ssh versus winrm

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -207,7 +207,7 @@ class Chef
         :long => "--bootstrap-protocol protocol",
         :description => "protocol to bootstrap windows servers. options: winrm/ssh",
         :proc => Proc.new { |key| Chef::Config[:knife][:bootstrap_protocol] = key },
-        :default => "winrm"
+        :default => "ssh"
 
       option :fqdn,
         :long => "--fqdn FQDN",


### PR DESCRIPTION
WinRM is new functionality, whereas previously ssh was the only functionality. We should default on the old behavior and have users indicate when they want winrm versus when they want SSH (since that's the old behavio)
