### PR TITLE
KNIFE-387: knife ec2 server create should accept bootstrap proxy option

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -137,6 +137,11 @@ class Chef
         :long => "--bootstrap-version VERSION",
         :description => "The version of Chef to install",
         :proc => Proc.new { |v| Chef::Config[:knife][:bootstrap_version] = v }
+      
+      option :bootstrap_proxy,
+          :long => "--bootstrap-proxy PROXY_URL",
+          :description => "The proxy server for the node being bootstrapped",
+          :proc => Proc.new { |p| Chef::Config[:knife][:bootstrap_proxy] = p }
 
       option :distro,
         :short => "-d DISTRO",


### PR DESCRIPTION
From https://github.com/opscode/knife-ec2/pull/141. 
