### PR TITLE
Remove escaped single quote to fix cosmetic display of summary

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors      = ['Adam Jacob', 'Seth Chisamore']
   s.email        = ['adam@opscode.com', 'schisamo@opscode.com']
   s.homepage     = 'https://github.com/opscode/knife-ec2'
-  s.summary      = %q{EC2 Support for Chef\'s Knife Command}
+  s.summary      = %q{EC2 Support for Chef's Knife Command}
   s.description  = s.summary
   s.license      = 'Apache 2.0'
 


### PR DESCRIPTION
Fixes the summary from looking like this-
EC2 Support for Chef\'s Knife Command

To looking like this-
EC2 Support for Chef's Knife Command
