### PR TITLE
Add --use-public-interface flag to force using the public ip/dns.

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -258,6 +258,12 @@ class Chef
         :boolean => true,
         :default => false        
 
+      option :use_public_interface,
+        :long => "--use-public-interface",
+        :description => "Use the public interface to initialize the VPC host.",
+        :boolean => true,
+        :default => false
+
     def tcp_test_winrm(ip_addr, port)
       tcp_socket = TCPSocket.new(ip_addr, port)
       yield
@@ -619,6 +625,11 @@ class Chef
           exit 1
         end
 
+        if !vpc_mode? and config[:use_public_interface]
+          ui.error("--use-public-interface option only applies to VPC instances, and you have not specified a subnet id.")
+          exit 1
+        end
+
         if config[:associate_eip]
           eips = connection.addresses.collect{|addr| addr if addr.domain == eip_scope}.compact
 
@@ -748,8 +759,10 @@ class Chef
       def ssh_connect_host
         @ssh_connect_host ||= if config[:server_connect_attribute]
           server.send(config[:server_connect_attribute])
+        elsif vpc_mode? and !config[:use_public_interface]
+          server.private_ip_address
         else
-          vpc_mode? ? server.private_ip_address : server.dns_name
+          server.dns_name
         end
       end
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -521,6 +521,13 @@ describe Chef::Knife::Ec2ServerCreate do
 
       lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
     end
+
+    it "disallows use pubic interface option when not using a VPC" do
+      @knife_ec2_create.config[:use_public_interface] = true
+      @knife_ec2_create.config[:subnet_id] = nil
+
+      lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
+    end
   end
 
   describe "when creating the server definition" do
@@ -654,9 +661,17 @@ describe Chef::Knife::Ec2ServerCreate do
     end
 
     describe "with vpc_mode?" do
-      it 'should use private ip' do
+      before(:each) do
         @knife_ec2_create.stub(:vpc_mode? => true)
+      end
+
+      it 'should use private ip' do
         @knife_ec2_create.ssh_connect_host.should == 'private_ip'
+      end
+
+      it "should use public interface if specified" do
+        @knife_ec2_create.config[:use_public_interface] = true
+        @knife_ec2_create.ssh_connect_host.should == 'public_name'
       end
     end
 


### PR DESCRIPTION
Not all VPC's necessarily have the full setup done for a customer
gateway.  When you don't have the VPN gateway in place, the private ip
is not accessible.  This option allows the user to force the server to
be initialized with the public interface.
