### PR TITLE
handle windows line endings in credentials file

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -95,7 +95,7 @@ class Chef
           # File format:
           # AWSAccessKeyId=somethingsomethingdarkside
           # AWSSecretKey=somethingsomethingcomplete
-          entries = Hash[*File.read(Chef::Config[:knife][:aws_credential_file]).split(/[=\n]/)]
+          entries = Hash[*File.read(Chef::Config[:knife][:aws_credential_file]).split(/[=\n]/).map(&:chomp)]
           Chef::Config[:knife][:aws_access_key_id] = entries['AWSAccessKeyId']
           Chef::Config[:knife][:aws_secret_access_key] = entries['AWSSecretKey']
         end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -494,6 +494,33 @@ describe Chef::Knife::Ec2ServerCreate do
       @knife_ec2_create.ui.stub(:error)
     end
 
+    describe "when reading aws_credential_file" do 
+      before do
+        Chef::Config[:knife].delete(:aws_access_key_id)
+        Chef::Config[:knife].delete(:aws_secret_access_key)
+
+        Chef::Config[:knife][:aws_credential_file] = '/apple/pear'
+        @access_key_id = 'access_key_id'
+        @secret_key = 'secret_key'
+      end
+
+      it "reads UNIX Line endings" do
+        File.stub(:read).
+          and_return("AWSAccessKeyId=#{@access_key_id}\nAWSSecretKey=#{@secret_key}")
+        @knife_ec2_create.validate!
+        Chef::Config[:knife][:aws_access_key_id].should == @access_key_id
+        Chef::Config[:knife][:aws_secret_access_key].should == @secret_key
+      end
+
+      it "reads DOS Line endings" do
+        File.stub(:read).
+          and_return("AWSAccessKeyId=#{@access_key_id}\r\nAWSSecretKey=#{@secret_key}")
+        @knife_ec2_create.validate!
+        Chef::Config[:knife][:aws_access_key_id].should == @access_key_id
+        Chef::Config[:knife][:aws_secret_access_key].should == @secret_key
+      end
+    end
+
     it "disallows security group names when using a VPC" do
       @knife_ec2_create.config[:subnet_id] = 'subnet-1a2b3c4d'
       @knife_ec2_create.config[:security_group_ids] = 'sg-aabbccdd'


### PR DESCRIPTION
@zsol forgot a little detail - now AWS credentials file may contain windows newline character and knife will still work
