### PR TITLE
EC2 server creation tunnelling should wait for a valid banner before continuing

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -286,9 +286,14 @@ class Chef
         tcp_socket = TCPSocket.new(hostname, ssh_port)
         readable = IO.select([tcp_socket], nil, nil, 5)
         if readable
-          Chef::Log.debug("sshd accepting connections on #{hostname}, banner is #{tcp_socket.gets}")
-          yield
-          true
+          ssh_banner = tcp_socket.gets
+          if ssh_banner.nil? or ssh_banner.empty?
+            false
+          else
+            Chef::Log.debug("sshd accepting connections on #{hostname}, banner is #{ssh_banner}")
+            yield
+            true
+          end
         else
           false
         end


### PR DESCRIPTION
Ticket filed:  https://tickets.opscode.com/browse/KNIFE-430

When creating a server inside a VPC, behind an SSH gateway, with a non-standard ebs backed volume size, ec2 will allow the network connection to become life and just actively refuse connections prior to the ebs volume being available and the machine running.  This leads to 'ERROR: Net::SSH::Disconnect: connection closed by remote host" when trying to bootstrap since the current tcp_test_ssh will return given the socket was able to open.

To remedy this, we ensure that the banner that is being retrieved already, and logged in debug mode, is not None, and not empty.

Steps to reproduce:
1. VPC with 2 subnets. 1 with public routable subnet, 1 with private IP (but still routable out to the internet).
2. SSH gateway already configured in public subnet.
3. Use knife to create an instance using an AWS standard AMI, with a larger ebs backed volume.
knife ec2 server create -r "role[BASE]" -f m1.large -I ami-6aad335a --subnet subnet-e3XXXXXb -x ubuntu -i ~/.ssh/YOUR_KEY.pem -S KEY_NAME -E ENV --security-group-id sg-bXXXXXd4 -Z us-west-2b -N pnw-host --server-connectttribute private_ip_address --ssh-gateway USER@gatewayhost.com --ebs-size 80

Ouput would be:
Instance ID: i-bXXXXX8d
Flavor: m1.large
Image: ami-6aad335a
Region: us-west-2
Availability Zone: us-west-2b
Security Group Ids: sg-bXXXXXd4
Tags: Name: pnw-host
SSH Key: KEY_NAME

Waiting for instance..................
Subnet ID: subnet-eXXXXXb
Private IP Address: 10.10.0.126
....done
Bootstrapping Chef on 10.10.0.126
ERROR: Net::SSH::Disconnect: connection closed by remote host

---

Opscode ticket created: https://tickets.opscode.com/browse/CHEF-4941
