### PR TITLE
OC-10743 - knife ec2 winrm ssl bootstrap

### DIFF
--- a/ec2-user-data/create-win-user.erb
+++ b/ec2-user-data/create-win-user.erb
@@ -1,0 +1,12 @@
+
+    $computer = [ADSI]"WinNT://$env:computername,computer"
+    $username = "<%= user_name %>"
+    $splitusername = $username.split("\\")
+    if ($splitusername[1] -eq $null) { $username = $splitusername[0] }
+    else { $username = $splitusername[1] }
+    $newuser = $computer.Create("user", $username)
+    $newuser.Path = $newuser.Path -replace(".\\", "")
+    $newuser.SetPassword("<%= user_passwd %>")
+    $newuser.SetInfo()
+    $localadmin = ([adsi]("WinNT://./Administrators,group"))
+    $localadmin.PSBase.Invoke("Add",$newuser.PSBase.Path)

--- a/ec2-user-data/create-win-user.erb
+++ b/ec2-user-data/create-win-user.erb
@@ -4,9 +4,16 @@
     $splitusername = $username.split("\\")
     if ($splitusername[1] -eq $null) { $username = $splitusername[0] }
     else { $username = $splitusername[1] }
-    $newuser = $computer.Create("user", $username)
-    $newuser.Path = $newuser.Path -replace(".\\", "")
-    $newuser.SetPassword("<%= user_passwd %>")
-    $newuser.SetInfo()
-    $localadmin = ([adsi]("WinNT://./Administrators,group"))
-    $localadmin.PSBase.Invoke("Add",$newuser.PSBase.Path)
+    $usersList = ($computer.psbase.children | Where-Object {$_.psBase.schemaClassName -eq "User"} | Select-Object -expand Name)
+    $userExists = $colUsers -contains $username
+    if ($userExists)
+    { "The user account exists." }
+    else
+    {
+        $newuser = $computer.Create("user", $username)
+        $newuser.Path = $newuser.Path -replace(".\\", "")
+        $newuser.SetPassword("<%= user_passwd %>")
+        $newuser.SetInfo()
+        $localadmin = ([adsi]("WinNT://./Administrators,group"))
+        $localadmin.PSBase.Invoke("Add",$newuser.PSBase.Path)
+    }

--- a/ec2-user-data/winrm-http.erb
+++ b/ec2-user-data/winrm-http.erb
@@ -1,0 +1,27 @@
+    # Generates the run log on VM at location: $env:temp\knife-ec2-user-data.log
+
+    echo "Starting knife winrm user-data script..." >> $env:temp\knife-ec2-user-data.log
+
+    # Get the instance ready for Chef bootstrapper, commands courtesy Julian Dunn
+    echo "Configuring winrm..." >> $env:temp\knife-ec2-user-data.log
+    winrm quickconfig -q
+    winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="300"}'
+    winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+    
+    echo "winrm e winrm/config/listener" >> $env:temp\knife-ec2-user-data.log
+    winrm e winrm/config/listener >> $env:temp\knife-ec2-user-data.log
+    
+    # open port 5985 in firewall
+    # Create an instance of the firewall rule object
+    $fwrule = New-Object -ComObject HNetCfg.FwRule
+
+    # Set the firewall rule properties
+    $fwrule.Name = "knife-winrm"
+    $fwrule.Protocol = 6
+    $fwrule.LocalPorts = 5985
+    $fwrule.Description = "Open winrm HTTP port"
+    $fwrule.Enabled = $true
+
+    # Create an instance of the firewall policy object
+    $fwpolicy = New-Object -ComObject HNetCfg.FwPolicy2
+    $fwpolicy.Rules.Add($fwrule)

--- a/ec2-user-data/winrm-ssl.erb
+++ b/ec2-user-data/winrm-ssl.erb
@@ -1,0 +1,55 @@
+    # Generates the run log on VM at location: $env:temp\knife-ec2-user-data.log
+    # Variables used in template
+    # - user_data_scripts_dir: folder containing the included script templates
+    # - base64_encoded_certificate: base64 encoded string for the (*.pfx) certificate contents to be deployed on the VM. 
+    # - certificate_passwd: password used during certificate (*.pfx) generation.
+    # - hostname_pattern: hostname pattern used in cert subject which is used to configure ssl listener
+    # - preserve_winrm_http: flag indicating whether to delete the winrm HTTP listener
+
+    echo "Starting knife winrm-ssl user-data script..." >> $env:temp\knife-ec2-user-data.log
+
+    <%= ERB.new(File.read(File.join(user_data_scripts_dir, "winrm-http.erb"))).result(binding) %>
+    
+    echo "Configuring winrm for SSL..." >> $env:temp\knife-ec2-user-data.log
+
+    # Delete the default listener and create one with cert thumb print
+    <%= "winrm delete winrm/config/Listener?Address=*+Transport=HTTP" if not preserve_winrm_http %>
+    
+    # write the cert in to local file
+    $Base64 = '<%= base64_encoded_certificate %>'
+
+    $Content = [System.Convert]::FromBase64String($Base64)
+
+    echo "Creating $env:temp\cert.pfx..." >> $env:temp\knife-ec2-user-data.log
+    Set-Content -Path $env:temp\cert.pfx -Value $Content -Encoding Byte
+
+    certutil -p <%= certificate_passwd %> -importPFX $env:temp\cert.pfx AT_KEYEXCHANGE >> $env:temp\knife-ec2-user-data.log
+    
+    $thumbprint = ls Cert:\LocalMachine\My | Select-Object -ExpandProperty Thumbprint
+
+    echo "Certificate thumbprint = $thumbprint" >> $env:temp\knife-ec2-user-data.log
+
+    # Create a HTTPS listener
+    echo "Creating winrm HTTPS listener..." >> $env:temp\knife-ec2-user-data.log
+    $winrmcmd = "winrm create winrm/config/listener?Address=*+Transport=HTTPS @{Hostname=`"<%= hostname_pattern %>`";CertificateThumbprint=`"$thumbprint`";Port=`"5986`"}"
+    
+    echo "Executing $winrmcmd..." >> $env:temp\knife-ec2-user-data.log
+    CMD /C $winrmcmd >> $env:temp\knife-ec2-user-data.log
+
+    echo "winrm e winrm/config/listener" >> $env:temp\knife-ec2-user-data.log
+    winrm e winrm/config/listener >> $env:temp\knife-ec2-user-data.log
+    
+    # Open port 5986 in firewall
+    # Create an instance of the firewall rule object
+    $fwrule = New-Object -ComObject HNetCfg.FwRule
+
+    # Set the firewall rule properties
+    $fwrule.Name = "knife-winrmssl"
+    $fwrule.Protocol = 6
+    $fwrule.LocalPorts = 5986
+    $fwrule.Description = "Open winrm ssl port"
+    $fwrule.Enabled = $true
+
+    # Create an instance of the firewall policy object
+    $fwpolicy = New-Object -ComObject HNetCfg.FwPolicy2
+    $fwpolicy.Rules.Add($fwrule)

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -87,7 +87,7 @@ class Chef
       end
 
       def is_image_windows?
-        image_info = connection.images.get(@server.image_id)
+        image_info = connection.images.get(locate_config_value(:image))
         return image_info.platform == 'windows'
       end
 

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -761,8 +761,6 @@ class Chef
 
         if is_image_windows?
           server_def.merge!(:user_data => load_windows_user_data)
-          puts load_windows_user_data
-          exit
         else
           if Chef::Config[:knife][:aws_user_data]
             begin

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -289,8 +289,8 @@ class Chef
         :boolean => true,
         :default => false
 
-      option :create_user,
-        :long => "--create-user",
+      option :create_winrm_user,
+        :long => "--create-winrm-user",
         :description => "Creates the user specified with --winrm-user flag. Default is false.",
         :boolean => true,
         :default => false
@@ -663,7 +663,7 @@ class Chef
           msg opt_parser
           exit 1
 
-        if locate_config_value(:bootstrap_protocol) == "winrm" and locate_config_value(:create_user)
+        if locate_config_value(:bootstrap_protocol) == "winrm" and locate_config_value(:create_winrm_user)
           toks = locate_config_value(:winrm_user).split("\\")
           user = (toks.length == 2) ? toks[1] : toks[0]
           if ['administrator', 'guest', 'admin'].include?(user.downcase)
@@ -672,7 +672,7 @@ class Chef
           end
           # Also password is must when creating a user on VM.
           if locate_config_value(:winrm_password).nil?
-            ui.error("--winrm-password is required when creating a user with --create-user option.")
+            ui.error("--winrm-password is required when creating a user with --create-winrm-user option.")
             exit 1
           end
         end
@@ -713,7 +713,7 @@ class Chef
         # If password is not specified on CLI, means user intends to use cert for auth
         # which is yet to be implemented/supported, if the user is already in image we cannot yet
         # retrieve it unless the VM is created.
-        if locate_config_value(:create_user)
+        if locate_config_value(:create_winrm_user)
           # Only create if explicitly requested
           create_user_ps = ERBHelpers::ERBCompiler.run(
             File.read(File.join(user_data_scripts_dir, "create-win-user.erb")),

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -666,7 +666,7 @@ class Chef
         if locate_config_value(:bootstrap_protocol) == "winrm" and locate_config_value(:create_user)
           toks = locate_config_value(:winrm_user).split("\\")
           user = (toks.length == 2) ? toks[1] : toks[0]
-          if ['administator', 'guest', 'admin'].include?(user.downcase)
+          if ['administrator', 'guest', 'admin'].include?(user.downcase)
             ui.error("Creating well known user names [admin, administator, guest] during VM creation is not supported.")
             exit 1
           end

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -662,6 +662,7 @@ class Chef
           ui.error("--ebs-volume-type must be 'standard' or 'io1' or 'gp2'")
           msg opt_parser
           exit 1
+        end
 
         if locate_config_value(:bootstrap_protocol) == "winrm" and locate_config_value(:create_winrm_user)
           toks = locate_config_value(:winrm_user).split("\\")

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -285,7 +285,7 @@ class Chef
 
       option :preserve_winrm_http,
         :long => "--preserve-winrm-http",
-        :description => "Preserve winrm HTTP listener. Only useful when configuring winrm ssl where HTTP listener is removed by default.",
+        :description => "Preserve winrm HTTP listener. Useful when image has preconfigured http transport (port 5985) which needs to be preserved. Default is false.",
         :boolean => true,
         :default => false
 

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -670,6 +670,11 @@ class Chef
             ui.error("Creating well known user names [admin, administator, guest] during VM creation is not supported.")
             exit 1
           end
+          # Also password is must when creating a user on VM.
+          if locate_config_value(:winrm_password).nil?
+            ui.error("--winrm-password is required when creating a user with --create-user option.")
+            exit 1
+          end
         end
       end
 

--- a/lib/chef/knife/helpers/erb.rb
+++ b/lib/chef/knife/helpers/erb.rb
@@ -1,0 +1,33 @@
+
+require 'erb'
+
+# Class to create an binding object with dynamically added instance variables.
+module ERBHelpers
+  # Usage: ERB.new("Hello <%= name %>!!").result(ERBParams.new(:name => "Ruby World").get_binding)
+  class ERBParams
+    def initialize(*args)
+      args.each do |arg|
+        arg.each do |key, value|
+          instance_variable_set("@#{key}", value)
+          # Add attribute accessor
+          eval("class << self; attr_accessor :#{key}; end")
+        end
+      end
+    end
+    def get_binding
+      binding
+    end
+  end
+
+  # Usage: ERBCompiler.run("Hello <%= name %>!!", {:name => "Ruby World"})
+  class ERBCompiler
+    def self.run(template, attributes)
+      begin
+        ERB.new(template).result(ERBParams.new(attributes).get_binding)
+      rescue NameError
+        puts "\n** Check whether all necessary ERB template substitution params are defined in attributes argument. #{attributes} \n\n"
+        raise
+      end
+    end
+  end
+end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -581,7 +581,8 @@ describe Chef::Knife::Ec2ServerCreate do
       lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
     end
 
-    it "disallows well known user names when --create-user option is specified" do
+
+    it "disallows well known user names when --create-winrm-user option is specified" do
       @knife_ec2_create.config[:bootstrap_protocol] = 'winrm'
       @knife_ec2_create.config[:winrm_user] = "Administrator"
       @knife_ec2_create.config[:winrm_password] = "password"
@@ -590,7 +591,7 @@ describe Chef::Knife::Ec2ServerCreate do
       lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
     end
 
-    it "password is compulsory when --create-user option is specified" do
+    it "password is compulsory when --create-winrm-user option is specified" do
       @knife_ec2_create.config[:bootstrap_protocol] = 'winrm'
       @knife_ec2_create.config[:winrm_user] = "Administrator"
       @knife_ec2_create.config[:winrm_password] = nil
@@ -787,7 +788,7 @@ describe Chef::Knife::Ec2ServerCreate do
           @knife_ec2_create.config[:bootstrap_protocol] = "winrm"
           @knife_ec2_create.config[:winrm_user] = "testuser_winrm"
           @knife_ec2_create.config[:winrm_password] = "testpassword_winrm"
-          @knife_ec2_create.config[:create_user] = true
+          @knife_ec2_create.config[:create_winrm_user] = true
         end
 
         it "user data includes user create script for testuser_winrm" do
@@ -846,7 +847,7 @@ describe Chef::Knife::Ec2ServerCreate do
           @knife_ec2_create.config[:bootstrap_protocol] = "ssh"
           @knife_ec2_create.config[:ssh_user] = "testuser_ssh"
           @knife_ec2_create.config[:ssh_password] = "testpassword_ssh"
-          @knife_ec2_create.config[:create_user] = true
+          @knife_ec2_create.config[:create_winrm_user] = true
         end
 
         it "user data include user create script for testuser_ssh" do
@@ -864,7 +865,7 @@ describe Chef::Knife::Ec2ServerCreate do
           @knife_ec2_create.config[:bootstrap_protocol] = "winrm"
           @knife_ec2_create.config[:winrm_user] = "testuser_winrm"
           @knife_ec2_create.config[:winrm_password] = "testpassword_winrm"
-          @knife_ec2_create.config[:create_user] = true
+          @knife_ec2_create.config[:create_winrm_user] = true
         end
 
         it "append user data to create user data when script tag is present" do

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -580,6 +580,24 @@ describe Chef::Knife::Ec2ServerCreate do
 
       lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
     end
+
+    it "disallows well known user names when --create-user option is specified" do
+      @knife_ec2_create.config[:bootstrap_protocol] = 'winrm'
+      @knife_ec2_create.config[:winrm_user] = "Administrator"
+      @knife_ec2_create.config[:winrm_password] = "password"
+      @knife_ec2_create.config[:create_winrm_user] = true
+
+      lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
+    end
+
+    it "password is compulsory when --create-user option is specified" do
+      @knife_ec2_create.config[:bootstrap_protocol] = 'winrm'
+      @knife_ec2_create.config[:winrm_user] = "Administrator"
+      @knife_ec2_create.config[:winrm_password] = nil
+      @knife_ec2_create.config[:create_winrm_user] = true
+
+      lambda { @knife_ec2_create.validate! }.should raise_error SystemExit
+    end
   end
 
   describe "when creating the connection" do
@@ -769,6 +787,7 @@ describe Chef::Knife::Ec2ServerCreate do
           @knife_ec2_create.config[:bootstrap_protocol] = "winrm"
           @knife_ec2_create.config[:winrm_user] = "testuser_winrm"
           @knife_ec2_create.config[:winrm_password] = "testpassword_winrm"
+          @knife_ec2_create.config[:create_user] = true
         end
 
         it "user data includes user create script for testuser_winrm" do
@@ -827,6 +846,7 @@ describe Chef::Knife::Ec2ServerCreate do
           @knife_ec2_create.config[:bootstrap_protocol] = "ssh"
           @knife_ec2_create.config[:ssh_user] = "testuser_ssh"
           @knife_ec2_create.config[:ssh_password] = "testpassword_ssh"
+          @knife_ec2_create.config[:create_user] = true
         end
 
         it "user data include user create script for testuser_ssh" do
@@ -844,6 +864,7 @@ describe Chef::Knife::Ec2ServerCreate do
           @knife_ec2_create.config[:bootstrap_protocol] = "winrm"
           @knife_ec2_create.config[:winrm_user] = "testuser_winrm"
           @knife_ec2_create.config[:winrm_password] = "testpassword_winrm"
+          @knife_ec2_create.config[:create_user] = true
         end
 
         it "append user data to create user data when script tag is present" do


### PR DESCRIPTION
Implements the functionality to bootstrap a VM using winrm over SSL, this involves setting up certificate (.pfx) on VM, configuring Winrm SSL listener on VM.
Adds support to use erb templates to be sent over AWS user-data for following:
- create a user on windows VM
- setup winrm
- setup winrm SSL
