### PR TITLE
OC-11210 EC2 refactored code has ambiguity in the name of short-option for Gateway & Groups

### DIFF
--- a/lib/chef/knife/cloud/ec2_server_create_options.rb
+++ b/lib/chef/knife/cloud/ec2_server_create_options.rb
@@ -28,7 +28,6 @@ class Chef
               :proc => Proc.new { |key| Chef::Config[:knife][:availability_zone] = key }
 
             option :ec2_ssh_key_id,
-              :short => "-S KEY",
               :long => "--ec2-ssh-key-id KEY",
               :description => "The ec2 SSH keypair id",
               :proc => Proc.new { |key| Chef::Config[:knife][:ec2_ssh_key_id] = key }

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -14,8 +14,8 @@ class Chef
     class Cloud
       class Ec2ServerCreate < ServerCreateCommand
         include Ec2Helpers
-        include Ec2ServerCreateOptions
         include Ec2ServiceOptions
+        include Ec2ServerCreateOptions
 
         banner "knife ec2 server create (options)"
 


### PR DESCRIPTION
Changes to fix short option -G --ec2-groups
For knife-cloud changes: https://github.com/opscode/knife-cloud/pull/54

^@adamedx
