### PR TITLE
Docs: Increase detail about necessary options for VPC instance creation

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -249,7 +249,7 @@ class Chef
       option :server_connect_attribute,
         :long => "--server-connect-attribute ATTRIBUTE",
         :short => "-a ATTRIBUTE",
-        :description => "The EC2 server attribute to use for SSH connection",
+        :description => "The EC2 server attribute to use for SSH connection. Use this attr for creating VPC instances along with --associate-eip",
         :default => nil
 
       option :associate_public_ip,


### PR DESCRIPTION
VPC instances will need --server-connect-attribute, especially when the
VPC instance is created with --associate-eip on the command line.
Without it, the SSH process in the knife ec2 server create will insist
on connecting to the original public IP address, rather than the new
EIP
