### PR TITLE
Knife should be able to create additional storage

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -18,6 +18,7 @@
 #
 
 require 'chef/knife/ec2_base'
+require 'chef/knife/ec2_volume_base'
 require 'chef/knife/winrm_base'
 
 class Chef
@@ -25,6 +26,7 @@ class Chef
     class Ec2ServerCreate < Knife
 
       include Knife::Ec2Base
+      include Knife::Ec2VolumeBase
       include Knife::WinrmBase
       deps do
         require 'fog'
@@ -173,6 +175,10 @@ class Chef
         :long => "--ebs-optimized",
         :description => "Enabled optimized EBS I/O"
 
+      option :use_additional_ebs,
+        :long => "--use-additional-ebs BOOLEAN",
+        :description => "Use Additonal EBS volumes BOOLEAN"
+
       option :ebs_no_delete_on_term,
         :long => "--ebs-no-delete-on-term",
         :description => "Do not delete EBS volume on instance termination"
@@ -274,6 +280,7 @@ class Chef
         elastic_ip = connection.addresses.detect{|addr| addr if addr.public_ip == requested_elastic_ip}
 
         @server = connection.servers.create(create_server_def)
+        @volumes = create_volumes!
 
         hashed_tags={}
         tags.map{ |t| key,val=t.split('='); hashed_tags[key]=val} unless tags.nil?
@@ -313,6 +320,7 @@ class Chef
         # wait for instance to come up before acting against it
         @server.wait_for { print "."; ready? }
 
+
         puts("\n")
 
         # occasionally 'ready?' isn't, so retry a couple times if needed.
@@ -326,6 +334,8 @@ class Chef
           sleep 5
           retry
         end
+
+        attach_volumes(@server.id, @volumes) if config[:use_additional_ebs]
 
         if vpc_mode?
           msg_pair("Subnet ID", @server.subnet_id)
@@ -444,6 +454,14 @@ class Chef
       def fetch_server_fqdn(ip_addr)
         require 'resolv'
         Resolv.getname(ip_addr)
+      end
+
+      def attach_volumes(server, volumes)
+        device_array = ('f'..'z').to_a
+
+        volumes.each_with_index do |volume, index|
+          connection.attach_volume(server, volume, "/dev/sd#{device_array[index]}" )
+        end
       end
 
       def bootstrap_for_windows_node(server, fqdn)
@@ -696,7 +714,7 @@ class Chef
         gw_user ||= ssh_gateway_config[:user]
 
         # Always use the gateway keys from the SSH Config
-        gateway_keys = ssh_gateway_config[:keys]        
+        gateway_keys = ssh_gateway_config[:keys]
 
         # Use the keys specificed on the command line if available (overrides SSH Config)
         if config[:ssh_gateway_identity]

--- a/lib/chef/knife/ec2_volume_base.rb
+++ b/lib/chef/knife/ec2_volume_base.rb
@@ -1,0 +1,78 @@
+require 'chef/knife'
+
+class Chef
+  class Knife
+    module Ec2VolumeBase
+
+      # :nodoc:
+      # Would prefer to do this in a rational way, but can't be done b/c of
+      # Mixlib::CLI's design :(
+      def self.included(includer)
+        includer.class_eval do
+
+          deps do
+            require 'fog'
+            require 'readline'
+            require 'chef/json_compat'
+          end
+
+          option :volume_count,
+            :short => "-c COUNT",
+            :long => "--volume-count COUNT",
+            :description => "Specify how many volume to create",
+            :default => 1
+
+          option :availability_zone,
+            :short => "-Z ZONE",
+            :long => "--availability-zone ZONE",
+            :description => "The Availability Zone",
+            :proc => Proc.new { |key| Chef::Config[:knife][:availability_zone] = key }
+
+          option :volume_size,
+            :short => "-S SIZE",
+            :long => "--size SIZE",
+            :description => "The size of the EBS volume in GB",
+            :proc => Proc.new { |size| Chef::Config[:knife][:volume_size] = size }
+
+          option :iops,
+            :short => "-io IOPS",
+            :long => "--iops IOPS",
+            :description => "Provisioned IOPS for the volume"
+
+          option :encrypted,
+            :short => "-e BOOLEAN",
+            :long => "--encrypted BOOLEAN",
+            :description => "BOOLEAN to determine EBS encryption",
+            :default => false
+        end
+      end
+
+      def create_volumes!
+        count = config[:volume_count].to_i
+        @volumes ||= []
+        options = {}
+        options['VolumeType'] = 'io1' if config[:iops]
+        options['Iops'] = config[:iops] if config[:iops]
+        #options['Encrypted'] = config[:encrypted]
+
+        count.times do |i|
+          volume = connection.create_volume(availability_zone,volume_size, options)
+          msg_pair("Availability Zone", volume.data[:body]["availabilityZone"])
+          msg_pair("Volume Size", volume.data[:body]["size"])
+          msg_pair("Volume ID", volume.data[:body]["volumeId"])
+          @volumes << volume.data[:body]["volumeId"]
+        end
+        @volumes
+      end
+
+      def volume_size
+        locate_config_value(:volume_size)
+      end
+
+      def availability_zone
+        locate_config_value(:availability_zone)
+      end
+
+    end
+  end
+end

--- a/lib/chef/knife/ec2_volume_create.rb
+++ b/lib/chef/knife/ec2_volume_create.rb
@@ -1,0 +1,57 @@
+#
+# Author:: Adam Jacob (<adam@opscode.com>)
+# Author:: Seth Chisamore (<schisamo@opscode.com>)
+# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/ec2_base'
+require 'chef/knife/ec2_volume_base'
+require 'chef/knife/winrm_base'
+
+class Chef
+  class Knife
+    class Ec2VolumeCreate < Knife
+
+      include Knife::Ec2Base
+      include Knife::Ec2VolumeBase
+      deps do
+        require 'fog'
+        require 'readline'
+        require 'chef/json_compat'
+        require 'chef/knife/bootstrap'
+        Chef::Knife::Bootstrap.load_deps
+      end
+
+      banner "knife ec2 volume create (options)"
+
+      attr_reader :volumes
+
+      def run
+        $stdout.sync = true
+
+        validate!
+        create_volumes!
+
+      end
+
+
+
+      def validate!
+        super([:aws_access_key_id, :aws_secret_access_key, :availability_zone, :volume_size])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'chef/knife/ec2_server_create'
 require 'chef/knife/ec2_instance_data'
 require 'chef/knife/ec2_server_delete'
 require 'chef/knife/ec2_server_list'
+require 'chef/knife/ec2_volume_create'
 
 # Clear config between each example
 # to avoid dependencies between examples

--- a/spec/unit/ec2_volume_create_spec.rb
+++ b/spec/unit/ec2_volume_create_spec.rb
@@ -1,0 +1,73 @@
+#
+# Author:: Thomas Bishop (<bishop.thomas@gmail.com>)
+# Copyright:: Copyright (c) 2010 Thomas Bishop
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path('../../spec_helper', __FILE__)
+require 'fog'
+require 'chef/knife/bootstrap'
+describe Chef::Knife::Ec2VolumeCreate do
+  before(:each) do
+    @knife_volume_create = Chef::Knife::Ec2VolumeCreate.new
+  end
+
+  describe "config options" do
+    it "sets the availability zone from CLI arguments over knife config" do
+      @knife_volume_create.config[:availability_zone] = "dis-one"
+      Chef::Config[:knife][:availability_zone] = "dat-one"
+      avaiability_zone = @knife_volume_create.availability_zone
+
+      avaiability_zone.should == "dis-one"
+    end
+
+    it "sets the volume size from CLI arguments over knife config" do
+      @knife_volume_create.config[:volume_size] = 5
+      Chef::Config[:knife][:volume_size] = 10
+      volume_size = @knife_volume_create.volume_size
+
+      volume_size.should == 5
+    end
+  end
+
+  describe ".run" do
+    before do
+      {
+        :aws_access_key_id => 'aws_access_key_id',
+        :aws_secret_access_key => 'aws_secret_access_key'
+      }.each do |key, value|
+        Chef::Config[:knife][key] = value
+      end
+
+      @ec2_connection = double(Fog::Compute::AWS)
+      @knife_volume_create.should_receive(:connection).twice.and_return(@ec2_connection)
+    end
+
+
+    it "passes along the availability and volume size to the create_volume" do
+      Chef::Config[:knife][:availability_zone] = "us-east-1a"
+      Chef::Config[:knife][:volume_size] = 5
+      @knife_volume_create.connection.should_receive(:create_volume).with("us-east-1a", 5).and_return(create_volume_response)
+
+      @knife_volume_create.run
+
+      @knife_volume_create.should_not == nil
+    end
+
+    def create_volume_response
+      double(data: {body: {"availabilityZone" => "us-east-1a", "size" => "5"}})
+    end
+  end
+end


### PR DESCRIPTION
- provides capability to create storage volumes
- volumes are attached to instance before bootstrapping

This pull request is initially for feedback.
- Tests are not complete
- The latest version of fog is not called in therefore certain features are not yet able to be implemented (encrypted volumes)
