### PR TITLE
showing error message for incorrect option input

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -631,13 +631,13 @@ class Chef
         end
 
         if(config[:security_groups] && config[:security_groups].class == String)
-          ui.error("security_groups should be provided as array")
-          exit
+          ui.error("Invalid value type for knife[:security_groups] in knife configuration file (i.e knife.rb). Type should be array. e.g - knife[:security_groups] = ['sgroup1']")
+          exit 1
         end
 
         if(config[:security_group_ids] && config[:security_group_ids].class == String)
-          ui.error("security_group_ids should be provided as array")
-          exit
+          ui.error("Invalid value type for knife[:security_group_ids] in knife configuration file (i.e knife.rb). Type should be array. e.g - knife[:security_group_ids] = ['sgroup1']")
+          exit 1
         end
       end
 


### PR DESCRIPTION
if security_groups and security_group_ids are not provided as an array
