### PR TITLE
fixed ffi-yajl warning issue

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'fog',           '~> 1.23.0'
   s.add_dependency 'knife-windows', '>= 0.8.2'
+  s.add_dependency "ffi-yajl", "< 1.3", "~> 1.2"
 
   s.add_development_dependency 'mixlib-config', '~> 2.0'
-  s.add_development_dependency 'chef',          '>= 11.16.2'
+  s.add_development_dependency 'chef',          '>= 11.16.2', '< 12'
   s.add_development_dependency 'rspec',         '~> 2.14'
   s.add_development_dependency 'rake',          '~> 10.1'
   s.add_development_dependency 'sdoc',          '~> 0.3'


### PR DESCRIPTION
Getting this warning with `ffi-yajl -v1.3.1 gem`:

```
failed to load the ffi-yajl c-extension, falling back to ffi interface
ffi-yajl/json_gem is deprecated, these monkeypatches will be dropped shortly
```
