### PR TITLE
Remove -s option for data bag secret because it conflicts with -s for subnets...

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -187,7 +187,6 @@ class Chef
         :proc => lambda { |o| o.split(/[\s,]+/) }
 
       option :secret,
-        :short => "-s SECRET",
         :long => "--secret ",
         :description => "The secret key to use to encrypt data bag item values",
         :proc => lambda { |s| Chef::Config[:knife][:secret] = s }


### PR DESCRIPTION
...which was there first.