### PR TITLE
Fix "warning: circular argument reference - filters" on Ruby 2.2

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables  = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_dependency 'fog',           '~> 1.25.0'
+  s.add_dependency 'fog',           '~> 1.29.0'
   s.add_dependency 'knife-windows', '>= 0.8.2'
 
   s.add_development_dependency 'mixlib-config', '~> 2.0'


### PR DESCRIPTION
See: http://stackoverflow.com/questions/27669855/warnings-after-upgrading-to-ruby-2-2-0

Fixes #286 