### PR TITLE
[KNIFE-464] Support EC2 STS, i.e. AWS Federation tokens for authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,8 @@ Icon?
 *.swo
 
 Gemfile.lock
+Guardfile
 .rspec
+
+.rvmrc
+.rbenv-gemsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: this log contains only changes from knife-ec2 release 0.8.0 and later
 prior to release 0.8.0, please visit the [source repository](https://github.com/opscode/knife-ec2/commits).
 
 ## Unreleased changes
+* [KNIFE-464](https://tickets.opscode.com/browse/KNIFE-464) Support EC2 STS, i.e. AWS Federation tokens for authentication
 * Use IAM role for credentials
 
 ## Latest release: 0.10.0.rc.1

--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -37,6 +37,10 @@ a data bag secret file -- this option can be used in place of the
 This option allows the validation key to be specified as a URL. It takes a URL
 as an argument.
 
+## Option `--aws-session-token`
+The option `--aws-session-token` was added for all knife-ec2 subcommands to
+allow support for federation use cases utilizing EC2 STS tokens.
+
 ## SSH Gateway from SSH Config
 Any available SSH Gateway settings in your SSH configuration file are now used
 by default. This includes using any SSH keys specified for the target host.
@@ -47,5 +51,11 @@ for complex command line invocations.
 You can pass an SSH key to be used for authenticating to the SSH Gateway with
 the --ssh-gateway-identity option.
 
+### options
 
-   
+```
+--aws-session-token
+```
+
+Your AWS Session Token, for use with AWS STS Federation or Session Tokens.
+This option is available for all subcommands.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ If your `knife.rb` file will be checked into a SCM system (ie readable by others
 ```ruby
 knife[:aws_access_key_id] = ENV['AWS_ACCESS_KEY_ID']
 knife[:aws_secret_access_key] = ENV['AWS_SECRET_ACCESS_KEY']
+# Optional if you're using Amazon's STS
+knife[:aws_session_token] = ENV['AWS_SESSION_TOKEN']
 ```
 
 You also have the option of passing your AWS API Key/Secret into the individual knife subcommands using the `-A` (or `--aws-access-key-id`) `-K` (or `--aws-secret-access-key`) command options
@@ -81,6 +83,7 @@ Additionally the following options may be set in your `knife.rb`:
 - image
 - availability_zone
 - aws_ssh_key_id
+- aws_session_token
 - region
 - distro
 - template_file

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -51,6 +51,11 @@ class Chef
             :description => "Your AWS API Secret Access Key",
             :proc => Proc.new { |key| Chef::Config[:knife][:aws_secret_access_key] = key }
 
+          option :aws_session_token,
+            :long => "--aws-session-token TOKEN",
+            :description => "Your AWS Session Token, for use with AWS STS Federation or Session Tokens",
+            :proc => Proc.new { |key| Chef::Config[:knife][:aws_session_token] = key }
+
           option :region,
             :long => "--region REGION",
             :description => "Your AWS region",
@@ -75,6 +80,7 @@ class Chef
         else
           connection_settings[:aws_access_key_id] = locate_config_value(:aws_access_key_id)
           connection_settings[:aws_secret_access_key] = locate_config_value(:aws_secret_access_key)
+          connection_settings[:aws_session_token] = locate_config_value(:aws_session_token)
         end
         @connection ||= begin
           connection = Fog::Compute.new(connection_settings)

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -666,6 +666,14 @@ describe Chef::Knife::Ec2ServerCreate do
         @knife_ec2_create.connection
       end
     end
+
+    describe "when aws_session_token is present" do
+      it "creates a connection using the session token" do
+        @knife_ec2_create.config[:aws_session_token] = 'session-token'
+        Fog::Compute::AWS.should_receive(:new).with(hash_including(:aws_session_token => 'session-token')).and_return(@ec2_connection)
+        @knife_ec2_create.connection
+      end
+    end
   end
 
   describe "when creating the server definition" do


### PR DESCRIPTION
[KNIFE-464](https://tickets.opscode.com/browse/KNIFE-464): Add support for the AWS session token to `knife ec2` commands.

Effectively, this is a revert of a revert due to contributor license issues. I've rebased and fixed the tests. My opscode contributor user is [cgg](https://supermarket.chef.io/users/cgg).

Related issue:
https://github.com/chef/knife-ec2/issues/276

Original merge (which was subsequently reverted):
https://github.com/chef/knife-ec2/pull/211/files

There were 3 tests failures, but those same 3 failures currently exist on master:
```
rspec ./spec/unit/ec2_server_create_spec.rb:436 # Chef::Knife::Ec2ServerCreate when configuring the bootstrap process configures the bootstrap to use prerelease versions of chef if specified
rspec ./spec/unit/ec2_server_create_spec.rb:1009 # Chef::Knife::Ec2ServerCreate tcp_test_ssh should return false if we do not get an ssh header
rspec ./spec/unit/ec2_server_create_spec.rb:1016 # Chef::Knife::Ec2ServerCreate tcp_test_ssh should return false if the socket isn't ready
```