### PR TITLE
s3_source: Lazy load fog library

### DIFF
--- a/lib/chef/knife/s3_source.rb
+++ b/lib/chef/knife/s3_source.rb
@@ -1,5 +1,3 @@
-require 'fog'
-
 class Chef
   class Knife
     class S3Source
@@ -30,6 +28,7 @@ class Chef
       end
 
       def fog
+        require 'fog' # lazy load the fog library to speed up the knife run
         @fog ||= Fog::Storage::AWS.new(
           aws_access_key_id: Chef::Config[:knife][:aws_access_key_id],
           aws_secret_access_key: Chef::Config[:knife][:aws_secret_access_key]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'chef/knife/ec2_server_list'
 # Clear config between each example
 # to avoid dependencies between examples
 RSpec.configure do |c|
+  c.filter_run_excluding :exclude => true
   c.before(:each) do
     Chef::Config.reset
     Chef::Config[:knife] ={}

--- a/spec/unit/s3_source_deps_spec.rb
+++ b/spec/unit/s3_source_deps_spec.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+#This spec can only be run separately from the rest due to inclusion of fog library in other specs.
+#rspec spec/unit/s3_source_deps_spec.rb
+
+describe 'Check Dependencies', :exclude => Object.constants.include?(:Fog) do
+  before(:each) do
+  end
+  it 'should not load fog by default' do
+    begin
+      Fog::Storage::AWS.new()
+    rescue Exception => e
+      expect(e).to be_a_kind_of(NameError)
+    end
+  end
+
+  it 'lazy loads fog' do
+    begin
+      Chef::Knife::S3Source.fetch('test')
+    rescue Exception => e
+      expect(e).to be_a_kind_of(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This speeds up all knife commands on systems where knife-ec2 plugin is
installed.

Benchmarks ( done with 'time' command):

| Command | Before | After | % Improvement |
|-------|-----|----|----|
knife help | 8.523s | 2.616s  | 69% |
knife search "chef_environment:prod" | 20.429s | 15.094 | 26% |
knife search "chef_environment:prod AND role:admin" | 10.625   | 5.125s | 51% |



