### PR TITLE
Added em-winrm dependency back

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1032,6 +1032,7 @@ class Chef
 
       def load_winrm_deps
         require 'winrm'
+        require 'em-winrm'
         require 'chef/knife/winrm'
         require 'chef/knife/bootstrap_windows_winrm'
         require 'chef/knife/bootstrap_windows_ssh'


### PR DESCRIPTION
`knife ec2 server create` command with negotiate protocol fails due to removal of this dependency as `knife-windows` released version still uses `em-winrm`