### PR TITLE
Make Travis run on container-based infrastructure for faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+language: ruby
+sudo: false
+
 rvm:
   - 2.0.0
-  - 2.1.0
+  - 2.1
   - 2.2
 script: bundle exec rspec --color --format progress


### PR DESCRIPTION
Also, don't pin 2.1 to 2.1.0.