### PR TITLE
Updates fog to only require the AWS libraries

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -29,7 +29,7 @@ class Chef
         includer.class_eval do
 
           deps do
-            require 'fog'
+            require 'fog/aws'
             require 'readline'
             require 'chef/json_compat'
           end

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -31,7 +31,7 @@ class Chef
       include Knife::BootstrapWindowsBase
       deps do
         require 'tempfile'
-        require 'fog'
+        require 'fog/aws'
         require 'uri'
         require 'readline'
         require 'chef/json_compat'

--- a/lib/chef/knife/s3_source.rb
+++ b/lib/chef/knife/s3_source.rb
@@ -38,7 +38,7 @@ class Chef
       end
 
       def fog
-        require 'fog' # lazy load the fog library to speed up the knife run
+        require 'fog/aws' # lazy load the fog library to speed up the knife run
         @fog ||= Fog::Storage::AWS.new(
           aws_access_key_id: Chef::Config[:knife][:aws_access_key_id],
           aws_secret_access_key: Chef::Config[:knife][:aws_secret_access_key]

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -20,7 +20,7 @@ require File.expand_path('../../spec_helper', __FILE__)
 require 'net/ssh/proxy/http'
 require 'net/ssh/proxy/command'
 require 'net/ssh/gateway'
-require 'fog'
+require 'fog/aws'
 require 'chef/knife/bootstrap'
 require 'chef/knife/bootstrap_windows_winrm'
 require 'chef/knife/bootstrap_windows_ssh'

--- a/spec/unit/ec2_server_delete_spec.rb
+++ b/spec/unit/ec2_server_delete_spec.rb
@@ -14,7 +14,7 @@
 #
 
 require File.expand_path('../../spec_helper', __FILE__)
-require 'fog'
+require 'fog/aws'
 
 
 describe Chef::Knife::Ec2ServerDelete do

--- a/spec/unit/s3_source_spec.rb
+++ b/spec/unit/s3_source_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../spec_helper', __FILE__)
-require 'fog'
+require 'fog/aws'
 
 describe Chef::Knife::S3Source do
   before(:each) do


### PR DESCRIPTION
The fog gem is a nice abstraction for all the cloud services, but it does make the gem quite large. As this is an EC2 specific gem I have updated `require` statement for `fog` from `require 'fog'` to `require 'fog/aws'` to reduce the amount the plugin needs to load. The fog team is working on modularizing their gem so this may lead to just including the `fog-aws` gem in the future. I think this is a step towards that.
It also may help with the load times referenced in #293 

cc/ @dwradcliffe @stonith 