### PR TITLE
Handle Errno::ENOTCONN when testing for sshd access

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1124,7 +1124,7 @@ class Chef
         else
           false
         end
-      rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, IOError
+      rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ENOTCONN, IOError
         Chef::Log.debug("ssh failed to connect: #{hostname}")
         sleep 2
         false


### PR DESCRIPTION
I got a `Errno::ENOTCONN` when running knife via tsocks (transparent SOCKS proxy) and I think it should be handled as a valid exception while waiting for SSHD to become available. `ENOTCONN` means 'Transport endpoint is not connected'.

BTW, I saw this issue https://github.com/chef/knife-ec2/issues/367 about guidelines for contributing being outdated and that's why I didn't create a ticket in JIRA, etc. Please let me know if I need to. 

Thanks!