### PR TITLE
Avoid sending nil runlist to Chef::Knife::Boostrap

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -194,7 +194,8 @@ class Chef
         :short => "-r RUN_LIST",
         :long => "--run-list RUN_LIST",
         :description => "Comma separated list of roles/recipes to apply",
-        :proc => lambda { |o| o.split(/[\s,]+/) }
+        :proc => lambda { |o| o.split(/[\s,]+/) },
+        :default => []
 
       option :secret,
         :long => "--secret ",


### PR DESCRIPTION
Also fixes chef/chef#4131, see also chef/chef#4149

I manually tested this and it worked (testing mixlib-cli is still nigh impossible?)