### PR TITLE
Remove instance colors

### DIFF
--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -46,21 +46,6 @@ class Chef
         :long => "--tags TAG1,TAG2",
         :description => "List of tags to output"
 
-      def fcolor(flavor)
-        case flavor
-        when "t1.micro"
-          fcolor = :blue
-        when "m1.small"
-          fcolor = :magenta
-        when "m1.medium"
-          fcolor = :cyan
-        when "m1.large"
-          fcolor = :green
-        when "m1.xlarge"
-          fcolor = :red
-        end
-      end
-
       def azcolor(az)
         case az
         when /a$/
@@ -141,11 +126,7 @@ class Chef
 
           server_list << server.public_ip_address.to_s
           server_list << server.private_ip_address.to_s
-
-          server_list << ui.color(
-                                  server.flavor_id.to_s,
-                                  fcolor(server.flavor_id.to_s)
-                                )
+          server_list << server.flavor_id.to_s
 
           if config[:az]
             server_list << ui.color(


### PR DESCRIPTION
We have hardcoded instance colors that show up in knife ec2 server list.
The colors are hard coded to incredibly old instance types.  We *could*
update this for the current instance types, but it would be outdated in
another quarter.  It's probably better to just remove this functionality
since it's confusing as-is.