### PR TITLE
Require fog-aws vs. fog

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_dependency 'fog',           '~> 1.29.0'
+  s.add_dependency 'fog-aws',       '~> 0.7'
   s.add_dependency 'knife-windows', '~> 1.0'
 
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -29,7 +29,7 @@ class Chef
         includer.class_eval do
 
           deps do
-            require 'fog'
+            require 'fog/aws'
             require 'readline'
             require 'chef/json_compat'
           end

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -31,7 +31,7 @@ class Chef
       include Knife::BootstrapWindowsBase
       deps do
         require 'tempfile'
-        require 'fog'
+        require 'fog/aws'
         require 'uri'
         require 'readline'
         require 'chef/json_compat'

--- a/lib/chef/knife/s3_source.rb
+++ b/lib/chef/knife/s3_source.rb
@@ -38,7 +38,7 @@ class Chef
       end
 
       def fog
-        require 'fog' # lazy load the fog library to speed up the knife run
+        require 'fog/aws' # lazy load the fog library to speed up the knife run
         @fog ||= Fog::Storage::AWS.new(
           aws_access_key_id: Chef::Config[:knife][:aws_access_key_id],
           aws_secret_access_key: Chef::Config[:knife][:aws_secret_access_key]

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -20,7 +20,7 @@ require File.expand_path('../../spec_helper', __FILE__)
 require 'net/ssh/proxy/http'
 require 'net/ssh/proxy/command'
 require 'net/ssh/gateway'
-require 'fog'
+require 'fog/aws'
 require 'chef/knife/bootstrap'
 require 'chef/knife/bootstrap_windows_winrm'
 require 'chef/knife/bootstrap_windows_ssh'

--- a/spec/unit/ec2_server_delete_spec.rb
+++ b/spec/unit/ec2_server_delete_spec.rb
@@ -14,7 +14,7 @@
 #
 
 require File.expand_path('../../spec_helper', __FILE__)
-require 'fog'
+require 'fog/aws'
 
 
 describe Chef::Knife::Ec2ServerDelete do

--- a/spec/unit/s3_source_spec.rb
+++ b/spec/unit/s3_source_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../spec_helper', __FILE__)
-require 'fog'
+require 'fog/aws'
 
 describe Chef::Knife::S3Source do
   before(:each) do


### PR DESCRIPTION
Fog started out as a monolithic project and is slowly being broken out into smaller libraries.  Fog rolls up all of the individual libraries to provide the same behavior in a backwards compatible form. Since we're only interacting with AWS all we really need is fog-aws which depends on fog-core, fog-json, and fog-xml.  Here's the positive results of this change:

Gems we will no longer be depending on:

Using inflecto 0.0.2
Using fog-brightbox 0.9.0
Using fog-ecloud 0.3.0
Using fog-local 0.2.1
Using fog-powerdns 0.1.1
Using fog-profitbricks 0.0.5
Using fog-radosgw 0.0.4
Using fog-riakcs 0.1.0
Using fog-sakuracloud 1.3.3
Using fog-serverlove 0.1.2
Using fog-softlayer 1.0.2
Using fog-storm_on_demand 0.1.1
Using fog-terremark 0.1.0
Using fog-vmfusion 0.1.0
Using fog-voxel 0.1.0
Using fog 1.29.0
Using fog-atmos 0.1.0
Using fission 0.5.0
Using CFPropertyList 2.3.2

Load time of the requires:

fog: 0m1.758s
fog-aws: 0m0.682s

So we speed up our load time by a second and we remove 19 dependencies.  Also since we're no longer depending directly on fog, we won't pin fog in a way that breaks people that use other knife cloud plugins as we've done in the past.