### PR TITLE
adding missing m4,d2,t2,and g2 ebs encryption flavors

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -813,10 +813,12 @@ class Chef
           if !locate_config_value(:flavor)
             ui.error("--ebs-encrypted option requires valid flavor to be specified.")
             exit 1
-          elsif (locate_config_value(:ebs_encrypted) and ! %w(m3.medium  m3.large  m3.xlarge m3.2xlarge c4.large c4.xlarge
+          elsif (locate_config_value(:ebs_encrypted) and ! %w(m3.medium  m3.large  m3.xlarge m3.2xlarge m4.large m4.xlarge
+                                             m4.2xlarge m4.4xlarge m4.10xlarge t2.micro t2.small t2.medium t2.large
+                                             d2.xlarge  d2.2xlarge d2.4xlarge d2.8xlarge c4.large c4.xlarge
                                              c4.2xlarge c4.4xlarge c4.8xlarge c3.large c3.xlarge c3.2xlarge
                                              c3.4xlarge c3.8xlarge cr1.8xlarge r3.large r3.xlarge r3.2xlarge
-                                             r3.4xlarge r3.8xlarge i2.xlarge i2.2xlarge i2.4xlarge i2.8xlarge g2.2xlarge).include?(locate_config_value(:flavor)))
+                                             r3.4xlarge r3.8xlarge i2.xlarge i2.2xlarge i2.4xlarge i2.8xlarge g2.2xlarge g2.8xlarge).include?(locate_config_value(:flavor)))
             ui.error("--ebs-encrypted option is not supported for #{locate_config_value(:flavor)} flavor.")
             exit 1
           end


### PR DESCRIPTION
I was getting this error:
--ebs-encrypted option is not supported for m4.large flavor.

I knew this was incorrect because its supported according to AWS docs:
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html

I put in a fix with latest instance types that support ebs encryption.