### PR TITLE
Please also read aws_session_token from credentials file

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -131,6 +131,7 @@ class Chef
 
             Chef::Config[:knife][:aws_access_key_id] = entries['AWSAccessKeyId'] || entries['aws_access_key_id']
             Chef::Config[:knife][:aws_secret_access_key] = entries['AWSSecretKey'] || entries['aws_secret_access_key']
+            Chef::Config[:knife][:aws_session_token] = entries['AWSSessionToken'] || entries['aws_session_token']
           end
 
           keys.each do |k|


### PR DESCRIPTION
The AWS session token from is supported as a knife option but overlooked when read from the aws credentials file. This one line update to ec2_base.rb fixes that for me. Hopefully, it helps others too.
