### PR TITLE
Fix security groups for spot requests in a VPC and make user input optional

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -421,7 +421,7 @@ class Chef
           msg_pair("Spot Price", spot_request.price)
 
           case config[:spot_wait_mode]
-          when 'prompt'
+          when 'prompt', '', nil
             wait_msg = "Do you want to wait for Spot Instance Request fulfillment? (Y/N) \n"
             wait_msg += "Y - Wait for Spot Instance request fulfillment\n"
             wait_msg += "N - Do not wait for Spot Instance request fulfillment. "

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -323,7 +323,7 @@ class Chef
           "Whether we should wait for spot request fulfillment. Could be 'wait', 'exit', or " \
           "'prompt' (default). For any of the above mentioned choices, ('wait') - if the " \
           "instance does not get allocated before the command itself times-out or ('exit') the " \
-          "user needs to manually bootstrap the instance in future after it gets allocated.",
+          "user needs to manually bootstrap the instance in the future after it gets allocated.",
         :default => "prompt"
 
       option :aws_connection_timeout,
@@ -421,7 +421,7 @@ class Chef
           msg_pair("Spot Price", spot_request.price)
 
           case config[:spot_wait_mode]
-          when 'prompt', '', nil
+          when 'prompt', '',
             wait_msg = "Do you want to wait for Spot Instance Request fulfillment? (Y/N) \n"
             wait_msg += "Y - Wait for Spot Instance request fulfillment\n"
             wait_msg += "N - Do not wait for Spot Instance request fulfillment. "

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -404,7 +404,9 @@ class Chef
         elastic_ip = connection.addresses.detect{|addr| addr if addr.public_ip == requested_elastic_ip}
 
         if locate_config_value(:spot_price)
-          spot_request = connection.spot_requests.create(create_server_def)
+          server_def = create_server_def
+          server_def[:groups] = config[:security_group_ids] if vpc_mode?
+          spot_request = connection.spot_requests.create(server_def)
           msg_pair("Spot Request ID", spot_request.id)
           msg_pair("Spot Request Type", spot_request.request_type)
           msg_pair("Spot Price", spot_request.price)

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -421,7 +421,7 @@ class Chef
           msg_pair("Spot Price", spot_request.price)
 
           case config[:spot_wait_mode]
-          when 'prompt', '',
+          when 'prompt', '', nil
             wait_msg = "Do you want to wait for Spot Instance Request fulfillment? (Y/N) \n"
             wait_msg += "Y - Wait for Spot Instance request fulfillment\n"
             wait_msg += "N - Do not wait for Spot Instance request fulfillment. "

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -317,6 +317,15 @@ class Chef
         :description => "The Spot Instance request type. Possible values are 'one-time' and 'persistent', default value is 'one-time'",
         :default => "one-time"
 
+      option :spot_wait_mode,
+        :long => "--spot-wait-mode MODE",
+        :description =>
+          "Whether we should wait for spot request fulfillment. Could be 'wait', 'exit', or " \
+          "'prompt' (default). For any of the above mentioned choices, ('wait') - if the " \
+          "instance does not get allocated before the command itself times-out or ('exit') the " \
+          "user needs to manually bootstrap the instance in future after it gets allocated.",
+        :default => "prompt"
+
       option :aws_connection_timeout,
         :long => "--aws-connection-timeout MINUTES",
         :description => "The maximum time in minutes to wait to for aws connection. Default is 10 min",
@@ -411,12 +420,23 @@ class Chef
           msg_pair("Spot Request Type", spot_request.request_type)
           msg_pair("Spot Price", spot_request.price)
 
-          wait_msg = "Do you want to wait for Spot Instance Request fulfillment? (Y/N) \n"
-          wait_msg += "Y - Wait for Spot Instance request fulfillment\n"
-          wait_msg += "N - Do not wait for Spot Instance request fulfillment. "
-          wait_msg += ui.color("[WARN :: Request would be alive on AWS ec2 side but execution of Chef Bootstrap on the target instance will get skipped.]\n", :red, :bold)
-          wait_msg += ui.color("\n[WARN :: For any of the above mentioned choices, (Y) - if the instance does not get allocated before the command itself times-out or (N) - user decides to exit, then in both cases user needs to manually bootstrap the instance in future after it gets allocated.]\n\n", :cyan, :bold)
-          confirm(wait_msg)
+          case config[:spot_wait_mode]
+          when 'prompt'
+            wait_msg = "Do you want to wait for Spot Instance Request fulfillment? (Y/N) \n"
+            wait_msg += "Y - Wait for Spot Instance request fulfillment\n"
+            wait_msg += "N - Do not wait for Spot Instance request fulfillment. "
+            wait_msg += ui.color("[WARN :: Request would be alive on AWS ec2 side but execution of Chef Bootstrap on the target instance will get skipped.]\n", :red, :bold)
+            wait_msg += ui.color("\n[WARN :: For any of the above mentioned choices, (Y) - if the instance does not get allocated before the command itself times-out or (N) - user decides to exit, then in both cases user needs to manually bootstrap the instance in future after it gets allocated.]\n\n", :cyan, :bold)
+            confirm(wait_msg)
+          when 'wait'
+            # wait for the node and run Chef bootstrap
+          when 'exit'
+            ui.color("The 'exit' option was specified for --spot-wait-mode, exiting.", :cyan)
+            exit
+          else
+            raise "Invalid value for --spot-wait-mode: '#{config[:spot_wait_mode]}', " \
+              "valid values: wait, exit, prompt"
+          end
 
           print ui.color("Waiting for Spot Request fulfillment:  ", :cyan)
           spot_request.wait_for do

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -426,7 +426,7 @@ class Chef
             wait_msg += "Y - Wait for Spot Instance request fulfillment\n"
             wait_msg += "N - Do not wait for Spot Instance request fulfillment. "
             wait_msg += ui.color("[WARN :: Request would be alive on AWS ec2 side but execution of Chef Bootstrap on the target instance will get skipped.]\n", :red, :bold)
-            wait_msg += ui.color("\n[WARN :: For any of the above mentioned choices, (Y) - if the instance does not get allocated before the command itself times-out or (N) - user decides to exit, then in both cases user needs to manually bootstrap the instance in future after it gets allocated.]\n\n", :cyan, :bold)
+            wait_msg += ui.color("\n[WARN :: For any of the above mentioned choices, (Y) - if the instance does not get allocated before the command itself times-out or (N) - user decides to exit, then in both cases user needs to manually bootstrap the instance in the future after it gets allocated.]\n\n", :cyan, :bold)
             confirm(wait_msg)
           when 'wait'
             # wait for the node and run Chef bootstrap


### PR DESCRIPTION
These changes were motivated by an attempt to create EC2 spot instances from an infrastructure orchestration script.

 - It looks like `:groups` is expected instead of `:security_group_ids` in the spot request creation API, even in the VPC mode.
 - To be able to fully automate spot instance setup, there needs to be a way to enable or disable wait for spot instance fulfillment without requesting any console input.