### PR TITLE
The addition of RI lease functionality to the knife-ec2 plugin

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_dependency 'fog-aws',       '~> 0.7'
-  s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_dependency 'fog-aws',       '~> 0.7'
+  s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -687,8 +687,8 @@ class Chef
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:first_boot_attributes] = locate_config_value(:first_boot_attributes)
         bootstrap.config[:first_boot_attributes_from_file] = locate_config_value(:first_boot_attributes_from_file)
-        bootstrap.config[:encrypted_data_bag_secret] = locate_config_value(:encrypted_data_bag_secret)
-        bootstrap.config[:encrypted_data_bag_secret_file] = locate_config_value(:encrypted_data_bag_secret_file)
+        bootstrap.config[:encrypted_data_bag_secret] = locate_config_value(:secret)
+        bootstrap.config[:encrypted_data_bag_secret_file] = locate_config_value(:secret_file)
         bootstrap.config[:secret] = s3_secret || locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)
         bootstrap.config[:node_ssl_verify_mode] = locate_config_value(:node_ssl_verify_mode)

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -687,7 +687,7 @@ class Chef
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:first_boot_attributes] = locate_config_value(:first_boot_attributes)
         bootstrap.config[:first_boot_attributes_from_file] = locate_config_value(:first_boot_attributes_from_file)
-        bootstrap.config[:encrypted_data_bag_secret] = locate_config_value(:secret)
+        bootstrap.config[:encrypted_data_bag_secret] = s3_secret || locate_config_value(:secret)
         bootstrap.config[:encrypted_data_bag_secret_file] = locate_config_value(:secret_file)
         bootstrap.config[:secret] = s3_secret || locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)

--- a/lib/chef/knife/ri_list.rb
+++ b/lib/chef/knife/ri_list.rb
@@ -23,16 +23,8 @@ class Chef
             
             include Knife::Ec2Base
             
-            #attr_accessor :hash_map_thing # hash_map_thing
-            
             banner "knife ri list - List all reserved instance leases defined in the aws cloud"
             
-            
-            option :tags,
-            :short => "-t TAG1,TAG2",
-            :long => "--tags TAG1,TAG2",
-            :description => "List of tags to output"
- 
             def build_ec2Map
                 ec2Servers = connection.servers
                 
@@ -134,7 +126,6 @@ class Chef
                                                 color
                                                 )
                             ri_list << ui.color((value.to_i - hash_map[resInst].to_i).to_s, color)
-                            #ri_list << ui.color(resInst["reservedInstancesId"].to_s, color)
                         end
                 
                 puts ui.list(ri_list, :uneven_columns_across, output_column_count)

--- a/lib/chef/knife/ri_list.rb
+++ b/lib/chef/knife/ri_list.rb
@@ -1,0 +1,146 @@
+#
+# Author:: Jimmy Coppens (jimmy@yhmg.com)
+# Copyright:: Copyright (c) 2010-2011 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'chef/knife/ec2_base'
+
+class Chef
+    class Knife
+        class RiList < Knife
+            
+            include Knife::Ec2Base
+            
+            #attr_accessor :hash_map_thing # hash_map_thing
+            
+            banner "knife ri list - List all reserved instance leases defined in the aws cloud"
+            
+            
+            option :tags,
+            :short => "-t TAG1,TAG2",
+            :long => "--tags TAG1,TAG2",
+            :description => "List of tags to output"
+ 
+            def build_ec2Map
+                ec2Servers = connection.servers
+                
+                hash_map = ec2Servers.inject({}) do |hash, o|
+                  if o.state == "running"
+                      if o.vpc_id
+                          vpc_or_not = " vpc"
+                      else
+                          vpc_or_not = " ec2"
+                      end
+                      
+                      key = o.flavor_id.to_s + " " + o.availability_zone.to_s + vpc_or_not
+                      hash[key] ||= 0
+                      hash[key] += 1
+                  end
+
+                  hash
+
+                end
+                
+                hash_map
+            
+            end
+
+            def build_riMap(ri_leases)
+                
+                hash_map = ri_leases.inject({}) do |hash, o|
+                    if o["reservedInstancesId"]
+
+                      if o["productDescription"].to_s == "Linux/UNIX (Amazon VPC)"
+                          vpc_or_not = " vpc"
+                          else
+                          vpc_or_not = " ec2"
+                      end
+                      
+                      key = o["instanceType"].to_s + " " + o["availabilityZone"].to_s + vpc_or_not 
+                      hash[key] ||= 0
+                      hash[key] += o["instanceCount"].to_i
+                    end
+                      hash
+                end
+
+                hash_map
+            end
+            
+            def lease_is_full(resInst, hash_map, hash_map_ri)
+
+                if hash_map[ resInst  ]
+                    
+                    if (hash_map[ resInst ]) >= (hash_map_ri [ resInst ])
+                        true
+                    else
+                        false
+                    end
+                else
+                    false
+                end
+            end
+ 
+            def run
+                $stdout.sync = true
+
+                validate!
+                
+                ri_list = [
+                ui.color('InstanceType', :bold),
+                ui.color('AvailabilityZone', :bold),
+                ui.color('Product', :bold),
+                ui.color('ResInstanceCount', :bold),
+                ui.color('InstanceDifference', :bold),
+                ].flatten.compact
+                
+                output_column_count = ri_list.length
+                
+                ri_leases = connection.describe_reserved_instances("state"=>"active").body["reservedInstancesSet"]
+
+                hash_map = build_ec2Map
+                hash_map_ri = build_riMap(ri_leases)
+
+                hash_map_ri.each do |resInst, value|
+                        
+                            color = lease_is_full(resInst, hash_map, hash_map_ri) ? :blue : :red
+                        
+                        
+                            ri_list << ui.color(
+                                                resInst.split(" ")[0].to_s,
+                                                color
+                                                )
+                             ri_list << ui.color(
+                                                 resInst.split(" ")[1].to_s,
+                                                 color
+                                                 )
+                            ri_list << ui.color(
+                                                resInst.split(" ")[2].to_s,
+                                                color
+                                                )
+                            ri_list <<  ui.color(
+                                                value.to_s,
+                                                color
+                                                )
+                            ri_list << ui.color((value.to_i - hash_map[resInst].to_i).to_s, color)
+                            #ri_list << ui.color(resInst["reservedInstancesId"].to_s, color)
+                        end
+                
+                puts ui.list(ri_list, :uneven_columns_across, output_column_count)
+                
+            end
+        end
+    end
+end
+

--- a/lib/knife-ec2/version.rb
+++ b/lib/knife-ec2/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Ec2
-    VERSION = "0.12.0"
+    VERSION = "0.13.0"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require 'chef/knife/ec2_server_list'
 # Clear config between each example
 # to avoid dependencies between examples
 RSpec.configure do |c|
-  c.raise_errors_for_deprecations!
+  #c.raise_errors_for_deprecations!
   c.filter_run_excluding :exclude => true
   c.before(:each) do
     Chef::Config.reset

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -443,6 +443,10 @@ describe Chef::Knife::Ec2ServerCreate do
         expect(bootstrap.config[:secret]).to eql("sys-knife-secret")
       end
 
+      it "sets encrypted_data_bag_secret" do
+        expect(bootstrap.config[:encrypted_data_bag_secret]).to eql("sys-knife-secret")
+      end
+
       it "prefers using a provided value instead of the knife confiuration" do
         subject.config[:secret] = "cli-provided-secret"
         expect(bootstrap.config[:secret]).to eql("cli-provided-secret")
@@ -456,6 +460,10 @@ describe Chef::Knife::Ec2ServerCreate do
 
       it "uses the the knife configuration when no explicit value is provided" do
         expect(bootstrap.config[:secret_file]).to eql("sys-knife-secret-file")
+      end
+
+      it "sets encrypted_data_bag_secret_file" do
+        expect(bootstrap.config[:encrypted_data_bag_secret_file]).to eql("sys-knife-secret-file")
       end
 
       it "prefers using a provided value instead of the knife confiuration" do


### PR DESCRIPTION
I created a new file called ri_list which lists all reserved instance leases, compares them to the current running instances.  It aggregates all instance leases to Instance Type, Availability Zone, Product [EC2 or VPC] and ResInstanceCount and Instance Difference.  See the below example output.

| InstanceType | AvailabilityZone | Product | ResInstanceCount | InstanceDifference |
| --- | --- | --- | --- | --- |
| c3.large | us-east-1d | vpc | 4 | 3 |
| c4.2xlarge       | us-east-1d | vpc | 10 | -1 |
| c4.large           | us-east-1d | vpc | 8                             |1|
| c3.2xlarge       | us-east-1d | vpc | 4                             |0|
| r3.2xlarge        | us-east-1d | vpc | 1                            |-1|
| m4.10xlarge    |us-east-1d | vpc | 2 | 0|


The Instance Difference is positive if there are open instances within the lease negative if the lease is full and you have instance types within the same parameters of the lease that are not reserved.  If the Instance Difference is zero than you are perfectly filling the lease. 

If the lease is Red it is open, if it is Blue it is full.
