### PR TITLE
Passing encrypted_data_bag_secret and encrypted_databag_secret_file

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_dependency 'fog-aws',       '~> 0.7'
-  s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_dependency 'fog-aws',       '~> 0.7'
+  s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -687,8 +687,8 @@ class Chef
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:first_boot_attributes] = locate_config_value(:first_boot_attributes)
         bootstrap.config[:first_boot_attributes_from_file] = locate_config_value(:first_boot_attributes_from_file)
-        bootstrap.config[:encrypted_data_bag_secret] = locate_config_value(:encrypted_data_bag_secret)
-        bootstrap.config[:encrypted_data_bag_secret_file] = locate_config_value(:encrypted_data_bag_secret_file)
+        bootstrap.config[:encrypted_data_bag_secret] = locate_config_value(:secret)
+        bootstrap.config[:encrypted_data_bag_secret_file] = locate_config_value(:secret_file)
         bootstrap.config[:secret] = s3_secret || locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)
         bootstrap.config[:node_ssl_verify_mode] = locate_config_value(:node_ssl_verify_mode)

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -687,7 +687,7 @@ class Chef
         bootstrap.config[:prerelease] = config[:prerelease]
         bootstrap.config[:first_boot_attributes] = locate_config_value(:first_boot_attributes)
         bootstrap.config[:first_boot_attributes_from_file] = locate_config_value(:first_boot_attributes_from_file)
-        bootstrap.config[:encrypted_data_bag_secret] = locate_config_value(:secret)
+        bootstrap.config[:encrypted_data_bag_secret] = s3_secret || locate_config_value(:secret)
         bootstrap.config[:encrypted_data_bag_secret_file] = locate_config_value(:secret_file)
         bootstrap.config[:secret] = s3_secret || locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -443,6 +443,10 @@ describe Chef::Knife::Ec2ServerCreate do
         expect(bootstrap.config[:secret]).to eql("sys-knife-secret")
       end
 
+      it "sets encrypted_data_bag_secret" do
+        expect(bootstrap.config[:encrypted_data_bag_secret]).to eql("sys-knife-secret")
+      end
+
       it "prefers using a provided value instead of the knife confiuration" do
         subject.config[:secret] = "cli-provided-secret"
         expect(bootstrap.config[:secret]).to eql("cli-provided-secret")
@@ -456,6 +460,10 @@ describe Chef::Knife::Ec2ServerCreate do
 
       it "uses the the knife configuration when no explicit value is provided" do
         expect(bootstrap.config[:secret_file]).to eql("sys-knife-secret-file")
+      end
+
+      it "sets encrypted_data_bag_secret_file" do
+        expect(bootstrap.config[:encrypted_data_bag_secret_file]).to eql("sys-knife-secret-file")
       end
 
       it "prefers using a provided value instead of the knife confiuration" do


### PR DESCRIPTION
Fix for https://github.com/chef/knife-ec2/issues/403

Issue is that `knife-windows` expects parameters as `encrypted_data_bag_secret` and `encrypted_data_bag_secret_file` while `chef` expects `secret` and `secret_file`.
We were only passing `secret` and `secret_file` from `knife-ec2`.