### PR TITLE
[GH-413] - Support ssh -W proxy

### DIFF
--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -1245,10 +1245,17 @@ describe Chef::Knife::Ec2ServerCreate do
       expect(@knife_ec2_create.get_ssh_gateway_for(hostname)).to eq(gateway)
     end
 
-    it "should return the ssh gateway specified in the ssh configuration even if the config option is not set" do
+    it "should return the ssh gateway specified in an ssh nc configuration even if the config option is not set" do
       # This should already be false, but test this explicitly for regression
       @knife_ec2_create.config[:ssh_gateway] = false
       allow(Net::SSH::Config).to receive(:for).and_return(:proxy => Net::SSH::Proxy::Command.new("ssh #{gateway} nc %h %p"))
+      expect(@knife_ec2_create.get_ssh_gateway_for(hostname)).to eq(gateway)
+    end
+
+    it "should return the ssh gateway specified in an ssh built-in forwarding configuration even if the config option is not set" do
+      # This should already be false, but test this explicitly for regression
+      @knife_ec2_create.config[:ssh_gateway] = false
+      allow(Net::SSH::Config).to receive(:for).and_return(:proxy => Net::SSH::Proxy::Command.new("ssh -options -W %h:%p -moreoptions #{gateway}"))
       expect(@knife_ec2_create.get_ssh_gateway_for(hostname)).to eq(gateway)
     end
 


### PR DESCRIPTION
Fixes #413.
- Look for 'ssh -W %h:%p gateway' in default ssh config
- When a proxy command is found but cannot be parsed, report it at the WARN
  level rather than DEBUG so the user is aware it is being ignored.
