### PR TITLE
Modified help for option --security-group-ids

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -67,8 +67,8 @@ class Chef
         :proc => Proc.new { |groups| groups.split(',') }
 
       option :security_group_ids,
-        :short => "-g X,Y,Z",
-        :long => "--security-group-ids X,Y,Z",
+        :short => "-g 'X,Y,Z'",
+        :long => "--security-group-ids 'X,Y,Z'",
         :description => "The security group ids for this server; required when using VPC,Please provide values in format --security-group-ids 'X,Y,Z'",
         :proc => Proc.new { |security_group_ids| security_group_ids.split(',') }
 

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -69,7 +69,7 @@ class Chef
       option :security_group_ids,
         :short => "-g X,Y,Z",
         :long => "--security-group-ids X,Y,Z",
-        :description => "The security group ids for this server; required when using VPC",
+        :description => "The security group ids for this server; required when using VPC,Please provide values in format --security-group-ids 'X,Y,Z'",
         :proc => Proc.new { |security_group_ids| security_group_ids.split(',') }
 
       option :associate_eip,


### PR DESCRIPTION
Updated description for option `--security-group-ids` which should be passed in comma separated format while running `knife ec2 server create` command 