### PR TITLE
Fixing --aws-config-file issues

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -120,12 +120,15 @@ class Chef
 
         if locate_config_value(:aws_config_file)
           aws_config = ini_parse(File.read(locate_config_value(:aws_config_file)))
-          profile = (locate_config_value(:aws_profile) == 'default') ? 'default' : 'profile '+locate_config_value(:aws_profile)
+          profile = if locate_config_value(:aws_profile) == 'default'
+                      'default'
+                    else
+                      "profile #{locate_config_value(:aws_profile)}"
+                    end
 
           unless aws_config.values.empty?
-            entries = aws_config[profile]
-            if entries
-              Chef::Config[:knife][:region] = entries['region']
+            if aws_config[profile]
+               Chef::Config[:knife][:region] = aws_config[profile]['region']
             else
               raise "The provided --aws-profile '#{profile}' is invalid."
             end
@@ -145,7 +148,7 @@ class Chef
             # aws_access_key_id = somethingsomethingdarkside
             # aws_secret_access_key = somethingsomethingdarkside
 
-            aws_creds = ini_parse(File.read(Chef::Config[:knife][:aws_credential_file]))
+            aws_creds = ini_parse(File.read(locate_config_value(:aws_credential_file)))
             profile = locate_config_value(:aws_profile) || 'default'
 
             entries = aws_creds.values.first.has_key?("AWSAccessKeyId") ? aws_creds.values.first : aws_creds[profile]

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -906,6 +906,22 @@ describe Chef::Knife::Ec2ServerCreate do
         expect(Chef::Config[:knife][:region]).to eq(@region)
       end
 
+      context "when invalid --aws-profile is given" do
+        it "raises exception" do
+          Chef::Config[:knife][:aws_profile] = 'xyz'
+          allow(File).to receive(:read).and_return("[default]\nregion=TESTREGION")
+          expect{ @knife_ec2_create.validate! }.to raise_error("The provided --aws-profile 'profile xyz' is invalid.")
+        end
+      end
+
+      context "when aws_profile is passed a 'default' from CLI or knife.rb file" do
+        it 'loads the default profile successfully' do
+          Chef::Config[:knife][:aws_profile] = 'default'
+          allow(File).to receive(:read).and_return("[default]\nregion=#{@region}\n\n[profile other]\nregion=TESTREGION")
+          @knife_ec2_create.validate!
+          expect(Chef::Config[:knife][:region]).to eq(@region)
+        end
+      end
     end
 
     it 'understands that file:// validation key URIs are just paths' do


### PR DESCRIPTION
Fixes the following:
1. If `--aws-profile` option is passed as "default" from CLI, it fails.
2. Proper exception is not raised if invalid `--aws-profile` is passed.
3. Preference should be given to options passed through CLI over options passed though `knife.rb`.