### PR TITLE
--aws-credential-file issues

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -151,7 +151,11 @@ class Chef
             aws_creds = ini_parse(File.read(locate_config_value(:aws_credential_file)))
             profile = locate_config_value(:aws_profile)
 
-            entries = aws_creds.values.first.has_key?("AWSAccessKeyId") ? aws_creds.values.first : aws_creds[profile]
+            entries = if aws_creds.values.first.has_key?("AWSAccessKeyId")
+                        aws_creds.values.first
+                      else
+                        aws_creds[profile]
+                      end
 
             if entries
               Chef::Config[:knife][:aws_access_key_id] = entries['AWSAccessKeyId'] || entries['aws_access_key_id']

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -46,7 +46,7 @@ class Chef
 
           option :aws_profile,
             :long => "--aws-profile PROFILE",
-            :description => "AWS profile, from credential file, to use",
+            :description => "AWS profile, from AWS credential file and AWS config file, to use",
             :default => 'default',
             :proc => Proc.new { |key| Chef::Config[:knife][:aws_profile] = key }
 
@@ -149,13 +149,17 @@ class Chef
             # aws_secret_access_key = somethingsomethingdarkside
 
             aws_creds = ini_parse(File.read(locate_config_value(:aws_credential_file)))
-            profile = locate_config_value(:aws_profile) || 'default'
+            profile = locate_config_value(:aws_profile)
 
             entries = aws_creds.values.first.has_key?("AWSAccessKeyId") ? aws_creds.values.first : aws_creds[profile]
 
-            Chef::Config[:knife][:aws_access_key_id] = entries['AWSAccessKeyId'] || entries['aws_access_key_id']
-            Chef::Config[:knife][:aws_secret_access_key] = entries['AWSSecretKey'] || entries['aws_secret_access_key']
-            Chef::Config[:knife][:aws_session_token] = entries['AWSSessionToken'] || entries['aws_session_token']
+            if entries
+              Chef::Config[:knife][:aws_access_key_id] = entries['AWSAccessKeyId'] || entries['aws_access_key_id']
+              Chef::Config[:knife][:aws_secret_access_key] = entries['AWSSecretKey'] || entries['aws_secret_access_key']
+              Chef::Config[:knife][:aws_session_token] = entries['AWSSessionToken'] || entries['aws_session_token']
+            else
+              raise "The provided --aws-profile '#{profile}' is invalid."
+            end
           end
 
           keys.each do |k|

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -130,7 +130,7 @@ class Chef
             if aws_config[profile]
                Chef::Config[:knife][:region] = aws_config[profile]['region']
             else
-              raise "The provided --aws-profile '#{profile}' is invalid."
+              raise ArgumentError, "The provided --aws-profile '#{profile}' is invalid."
             end
           end
         end
@@ -162,7 +162,7 @@ class Chef
               Chef::Config[:knife][:aws_secret_access_key] = entries['AWSSecretKey'] || entries['aws_secret_access_key']
               Chef::Config[:knife][:aws_session_token] = entries['AWSSessionToken'] || entries['aws_session_token']
             else
-              raise "The provided --aws-profile '#{profile}' is invalid."
+              raise ArgumentError, "The provided --aws-profile '#{profile}' is invalid."
             end
           end
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -890,6 +890,14 @@ describe Chef::Knife::Ec2ServerCreate do
         expect(Chef::Config[:knife][:aws_access_key_id]).to eq(@access_key_id)
         expect(Chef::Config[:knife][:aws_secret_access_key]).to eq(@secret_key)
       end
+
+      context "when invalid --aws-profile is given" do
+        it "raises exception" do
+          Chef::Config[:knife][:aws_profile] = 'xyz'
+          allow(File).to receive(:read).and_return("[default]\naws_access_key_id=TESTKEY\r\naws_secret_access_key=TESTSECRET")
+          expect{ @knife_ec2_create.validate! }.to raise_error("The provided --aws-profile 'xyz' is invalid.")
+        end
+      end
     end
 
 


### PR DESCRIPTION
Fixes the following:
1. Throws an error when invalid `--aws-profile` is passed
2. The description of `--aws-profile` option is specific to `--aws-credential-file`, while it is used by `--aws-config-file` too now. Modify the description.