### PR TITLE
Add support for 'region' in the .aws/credentials file

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -161,6 +161,10 @@ class Chef
               Chef::Config[:knife][:aws_access_key_id] = entries['AWSAccessKeyId'] || entries['aws_access_key_id']
               Chef::Config[:knife][:aws_secret_access_key] = entries['AWSSecretKey'] || entries['aws_secret_access_key']
               Chef::Config[:knife][:aws_session_token] = entries['AWSSessionToken'] || entries['aws_session_token']
+              Chef::Config[:knife][:region] = entries['region']
+              if !Chef::Config[:knife][:region]
+                ui.warn "No region was specified in knife.rb or as an argument. The default region, us-east-1, will be used:"
+              end
             else
               raise ArgumentError, "The provided --aws-profile '#{profile}' is invalid."
             end

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -113,10 +113,6 @@ class Chef
 
         output_column_count = server_list.length
 
-        if !config[:region] && Chef::Config[:knife][:region].nil?
-          ui.warn "No region was specified in knife.rb or as an argument. The default region, us-east-1, will be used:"
-        end
-
         servers = connection.servers
         if (config[:format] == 'summary')
           servers.each do |server|


### PR DESCRIPTION
The AWS 'region' value is not pulled from the .aws/credentials file. This patch adds support and suppresses the warning if it is not appropriate.
