### PR TITLE
New Feature: Allow re-use of existing ENI for primary interface

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -103,6 +103,10 @@ class Chef
         :description => "The placement group to place a cluster compute instance",
         :proc => Proc.new { |pg| Chef::Config[:knife][:placement_group] = pg }
 
+      option :primary_eni,
+        :long => "--primary-eni ENI_ID",
+        :description => "Specify a pre-existing eni to use when building the instance."
+
       option :tags,
         :short => "-T T=V[,T=V,...]",
         :long => "--tags Tag=Value[,Tag=Value...]",
@@ -609,6 +613,7 @@ class Chef
         msg_pair("Security Groups", printed_security_groups) unless vpc_mode? or (@server.groups.nil? and @server.security_group_ids)
         msg_pair("Security Group Ids", printed_security_group_ids) if vpc_mode? or @server.security_group_ids
         msg_pair("IAM Profile", locate_config_value(:iam_instance_profile)) if locate_config_value(:iam_instance_profile)
+        msg_pair("Primary ENI", locate_config_value(:primary_eni)) if locate_config_value(:primary_eni)
         msg_pair("Tags", printed_tags)
         msg_pair("SSH Key", @server.key_name)
         msg_pair("Root Device Type", @server.root_device_type)
@@ -1021,6 +1026,7 @@ EOH
         server_def[:private_ip_address] = locate_config_value(:private_ip_address) if vpc_mode?
         server_def[:placement_group] = locate_config_value(:placement_group)
         server_def[:iam_instance_profile_name] = locate_config_value(:iam_instance_profile)
+        server_def[:network_interfaces] = [ { :NetworkInterfaceId => locate_config_value(:primary_eni), :DeviceIndex => "0" } ]
         server_def[:tenancy] = "dedicated" if vpc_mode? and locate_config_value(:dedicated_instance)
         server_def[:associate_public_ip] = locate_config_value(:associate_public_ip) if vpc_mode? and config[:associate_public_ip]
 

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1021,12 +1021,21 @@ EOH
           :request_type => locate_config_value(:spot_request_type)
         }
 
-        server_def[:security_group_ids] = locate_config_value(:security_group_ids)
-        server_def[:subnet_id] = locate_config_value(:subnet_id) if vpc_mode?
+        if primary_eni = locate_config_value(:primary_eni)
+          server_def[:network_interfaces] = [
+            {
+              :NetworkInterfaceId => primary_eni,
+              :DeviceIndex => "0"
+            }
+          ]
+        else
+          server_def[:security_group_ids] = locate_config_value(:security_group_ids)
+          server_def[:subnet_id] = locate_config_value(:subnet_id) if vpc_mode?
+        end
+
         server_def[:private_ip_address] = locate_config_value(:private_ip_address) if vpc_mode?
         server_def[:placement_group] = locate_config_value(:placement_group)
         server_def[:iam_instance_profile_name] = locate_config_value(:iam_instance_profile)
-        server_def[:network_interfaces] = [ { :NetworkInterfaceId => locate_config_value(:primary_eni), :DeviceIndex => "0" } ]
         server_def[:tenancy] = "dedicated" if vpc_mode? and locate_config_value(:dedicated_instance)
         server_def[:associate_public_ip] = locate_config_value(:associate_public_ip) if vpc_mode? and config[:associate_public_ip]
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2245,4 +2245,19 @@ netstat > c:\\netstat_data.txt
       end
     end
   end
+
+  describe '--primary_eni option' do
+    before do
+      allow(Fog::Compute::AWS).to receive(:new).and_return(ec2_connection)
+    end
+
+    context 'when a preexisting eni is specified eg. eni-12345678 use that eni for device index 0' do
+      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--primary-eni', 'eni-12345678']) }
+      it 'provides a network_interfaces list of hashes with on element for the primary interface' do
+        server_def = ec2_server_create.create_server_def
+        expect(server_def[:network_interfaces]).to eq([{:NetworkInterfaceId => 'eni-12345678', :DeviceIndex => '0'}])
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
I need to be able to re-use an available ENI by attaching it as the primary interface. This change allows me to do so.
