### PR TITLE
Fix where yes option wasn’t being passed to bootstrap

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -735,6 +735,7 @@ class Chef
         bootstrap.config[:bootstrap_vault_json] = locate_config_value(:bootstrap_vault_json)
         bootstrap.config[:bootstrap_vault_item] = locate_config_value(:bootstrap_vault_item)
         bootstrap.config[:use_sudo_password] = locate_config_value(:use_sudo_password)
+        bootstrap.config[:yes] = locate_config_value(:yes)
         # Modify global configuration state to ensure hint gets set by
         # knife-bootstrap
         Chef::Config[:knife][:hints] ||= {}


### PR DESCRIPTION
During a validatorless bootstrap, knife ec2 server create will prompt the user “Node XXX exists, overwrite it? (Y/N)” if the node already exists.  Passing the --yes option should confirm this prompt automatically, but it does not.

Obvious fix.