### PR TITLE
Changed source of vm name to allow for hosts without public ip addresses

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -971,7 +971,7 @@ If (-Not (Get-Service WinRM | Where-Object {$_.status -eq "Running"})) {
 If (winrm e winrm/config/listener | Select-String -Pattern " Transport = HTTP\\b" -Quiet) {
   winrm delete winrm/config/listener?Address=*+Transport=HTTP
 }
-$vm_name = invoke-restmethod -uri http://169.254.169.254/latest/meta-data/public-ipv4
+$vm_name = invoke-restmethod -uri http://169.254.169.254/latest/meta-data/local-ipv4
 New-SelfSignedCertificate -certstorelocation cert:\\localmachine\\my -dnsname $vm_name
 $thumbprint = (Get-ChildItem -Path cert:\\localmachine\\my | Where-Object {$_.Subject -match "$vm_name"}).Thumbprint;
 $create_listener_cmd = "winrm create winrm/config/Listener?Address=*+Transport=HTTPS '@{Hostname=`"$vm_name`";CertificateThumbprint=`"$thumbprint`"}'"


### PR DESCRIPTION
Without this, the user-data script for Winodws hosts without an public IP address fails. This still works for Windows hosts with a public ip address.