### PR TITLE
Loosen deps on fog-aws and rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ language: ruby
 cache: bundler
 sudo: false
 
-# Early warning system to catch if Rubygems breaks something
+branches:
+  only:
+    - master
+
 before_install:
   - gem update --system
   - gem install bundler
-  - rm -f .bundle/config
+  - bundle --version
+  - gem --version
 
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - 2.4.4
 script: bundle exec rake spec

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,13 +17,13 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency 'fog-aws',       '~> 0.7'
+  s.add_dependency 'fog-aws',       '>= 0.7', '< 2.0.0'
   s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 
   s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'rake',  '~> 11.0'
+  s.add_development_dependency 'rake',  '>= 11.0', '< 13.0'
   s.add_development_dependency 'sdoc',  '~> 0.3'
 
   s.require_paths = ['lib']


### PR DESCRIPTION
The new fog-aws (1.1) introduces support for additional regions and
instance sizes. We should make sure we pull that in so we can support
those as well. It doesn't seem like they actually broke anything when
they went 1.0.

While I was here I added testing on Ruby 2.4 and removed branch testing
to avoid double testing PRs. We do that everywhere chef/*

Signed-off-by: Tim Smith <tsmith@chef.io>