### PR TITLE
Allow search for EC2 AMIs

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency 'fog-aws',       '~> 1.2'
+  s.add_dependency 'fog-aws',       '~> 1.0'
   s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency 'fog-aws',       '~> 0.7'
+  s.add_dependency 'fog-aws',       '~> 1.2'
   s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 

--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -1,0 +1,101 @@
+#
+# Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
+# Copyright:: Copyright (c) 2010-2015 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "chef/knife/ec2_base"
+
+class Chef
+  class Knife
+    class Ec2AmiList < Knife
+
+      # == Overview
+      #
+      # This file provides the facility to display AMI list.
+      #
+      # == Owner
+      # By default owner is aws-marketplace but you can specify following owner with the help of -o or --owner
+      #   * self => Displays the list of AMIs created by the user
+      #   * aws-marketplace => Displays all AMIs form trusted vendors like Ubuntu, Microsoft, SAP, Zend as well as many open source offering
+      #   * micosoft => Displays only Microsoft vendor AMIs
+      # 
+      # == Platform
+      # By default all platform AMI's will display but you can filter your response
+      # by specify the platform using -p or --platform
+      #  * Valid Platform => ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco
+      #
+      # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html]
+
+      include Knife::Ec2Base
+
+      banner "knife ec2 ami list (options)"
+
+      option :platform,
+        :short => "-p PLATFORM",
+        :long => "--platform PLATFORM",
+        :description => "The server valid platform (ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco)"
+
+       option :owner,
+        :short => "-o OWNER",
+        :long => "--owner OWNER",
+        :description => "The server owner (self, aws-marketplace, microsoft). Default is aws-marketplace"
+
+      def run
+        $stdout.sync = true
+
+        validate!
+        custom_warnings!
+
+        server_list = [
+          ui.color("AMI ID", :bold),
+          ui.color("Platform", :bold),
+          ui.color("Architecture", :bold),
+          ui.color("Size", :bold),
+          ui.color("Name", :bold)
+        ].flatten.compact
+
+        output_column_count = server_list.length
+        begin
+          owner = locate_config_value(:owner) || "aws-marketplace"
+          servers = connection.describe_images({"Owner"=>"#{owner}"}) # aws-marketplace, microsoft
+        rescue Exception => api_error
+          raise api_error
+        end
+        servers.body["imagesSet"].each do |server|
+          server_name = server["name"]
+          server["platform"] = find_server_platform(server_name) unless server["platform"]
+
+          if locate_config_value(:platform)
+            if server["platform"] == locate_config_value(:platform)
+              server_list << server["imageId"]
+              server_list << server["platform"]
+              server_list << server["architecture"]
+              server_list << server["blockDeviceMapping"].first["volumeSize"].to_s
+              server_list << server_name.split(/\W+/).first
+            end
+          else
+            server_list << server["imageId"]
+            server_list << server["platform"]
+            server_list << server["architecture"]
+            server_list << server["blockDeviceMapping"].first["volumeSize"].to_s
+            server_list << server_name.split(/\W+/).first
+          end
+        end
+        puts ui.list(server_list, :uneven_columns_across, output_column_count)
+      end
+    end
+  end
+end

--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Piyush Awasthi (<piyush.awasthi@msystechnologies.com>)
-# Copyright:: Copyright (c) 2010-2015 Chef Software, Inc.
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -46,7 +46,7 @@ class Chef
       option :platform,
         :short => "-p PLATFORM",
         :long => "--platform PLATFORM",
-        :description => "The server valid platform (ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco)"
+        :description => "Platform of the server. Allowed values are ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco, amazon, nessus"
 
        option :owner,
         :short => "-o OWNER",

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -179,14 +179,14 @@ class Chef
         end
 
         if locate_config_value(:platform)
-          unless valid_platform.include? (locate_config_value(:platform))
-            raise ArgumentError, "The platform should be #{valid_platform.join(", ")}."
+          unless valid_platforms.include? (locate_config_value(:platform))
+            raise ArgumentError, "Invalid platform: #{locate_config_value(:platform)}. Allowed platforms are: #{valid_platforms.join(", ")}."
           end
         end
 
         if locate_config_value(:owner)
           unless ["self", "aws-marketplace", "microsoft"].include? (locate_config_value(:owner))
-            raise ArgumentError, "The owner should be self, aws-marketplace or microsoft."
+            raise ArgumentError, "Invalid owner: #{locate_config_value(:owner)}. Allowed owners are self, aws-marketplace or microsoft."
           end
         end
       end
@@ -220,15 +220,15 @@ class Chef
       map
     end
 
-    # All valid platform
-    def valid_platform
+    # All valid platforms
+    def valid_platforms
       ["ubuntu", "debian", "centos", "fedora", "rhel", "nginx", "turnkey", "jumpbox", "coreos", "cisco", "amazon", "nessus"]
     end
 
     # Get the platform from server name
     def find_server_platform(server_name)
-      available_platform = valid_platform
-      get_platform = available_platform.select { |name| server_name.downcase.include?(name) }
+      available_platforms = valid_platforms
+      get_platform = available_platforms.select { |name| server_name.downcase.include?(name) }
       return get_platform.first
     end
 

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -222,7 +222,7 @@ class Chef
 
     # All valid platform
     def valid_platform
-      ["ubuntu", "debian", "centos", "fedora", "rhel", "nginx", "turnkey", "jumpbox", "coreos", "cisco"]
+      ["ubuntu", "debian", "centos", "fedora", "rhel", "nginx", "turnkey", "jumpbox", "coreos", "cisco", "amazon", "nessus"]
     end
 
     # Get the platform from server name

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -177,6 +177,18 @@ class Chef
             exit 1
           end
         end
+
+        if locate_config_value(:platform)
+          unless valid_platform.include? (locate_config_value(:platform))
+            raise ArgumentError, "The platform should be #{valid_platform.join(", ")}."
+          end
+        end
+
+        if locate_config_value(:owner)
+          unless ["self", "aws-marketplace", "microsoft"].include? (locate_config_value(:owner))
+            raise ArgumentError, "The owner should be self, aws-marketplace or microsoft."
+          end
+        end
       end
 
     end
@@ -206,6 +218,26 @@ class Chef
         end
       end
       map
+    end
+
+    # All valid platform
+    def valid_platform
+      ["ubuntu", "debian", "centos", "fedora", "rhel", "nginx", "turnkey", "jumpbox", "coreos", "cisco"]
+    end
+
+    # Get the platform from server name
+    def find_server_platform(server_name)
+      available_platform = valid_platform
+      get_platform = available_platform.select { |name| server_name.downcase.include?(name) }
+      return get_platform.first
+    end
+
+
+    # Custom Warning
+    def custom_warnings!
+      if !config[:region] && Chef::Config[:knife][:region].nil?
+        ui.warn "No region was specified in knife.rb or as an argument. The default region, us-east-1, will be used:"
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'chef/knife/winrm_base'
 require 'chef/knife/ec2_server_create'
 require 'chef/knife/ec2_server_delete'
 require 'chef/knife/ec2_server_list'
+require 'chef/knife/ec2_ami_list'
 
 # Clear config between each example
 # to avoid dependencies between examples

--- a/spec/unit/ec2_ami_list_spec.rb
+++ b/spec/unit/ec2_ami_list_spec.rb
@@ -1,275 +1,273 @@
-# License:: Apache License, Version 2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+  # License:: Apache License, Version 2.0
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  #
 
-require File.expand_path('../../spec_helper', __FILE__)
-require 'fog/aws'
+  require File.expand_path('../../spec_helper', __FILE__)
+  require 'fog/aws'
 
-describe Chef::Knife::Ec2AmiList do
+  describe Chef::Knife::Ec2AmiList do
 
-  describe '#run' do
-    let(:knife_ec2_ami_list) { Chef::Knife::Ec2AmiList.new }
-    let(:ec2_connection) { double(Fog::Compute::AWS) }
-    before do
-      allow(knife_ec2_ami_list).to receive(:connection).and_return(ec2_connection)
-      @describe_images_format = double("describe_image_output", :body => { 
-            'imagesSet'    => [{
-            'architecture'        => "x86_64",
-            'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
-                                       "snapshotId"=>"snap-f7e645f4",
-                                       "volumeSize"=>30,
-                                       "deleteOnTermination"=>"true",
-                                       "volumeType"=>"standard",
-                                       "encrypted"=>"false"}],
-            'description'         => "DC for Quan",
-            'hypervisor'          => "xen",
-            'imageId'             => "ami-4ace6d23",
-            'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
-            'imageOwnerAlias'     => "microsoft",
-            'name'                => "Windows_Server-2008-R2-SP1-English-64Bit-Windows_Media_Services_4.1-2012.06.12",
-            'imageOwnerId'        => "461346954234",
-            'imageState'          => "available",
-            'imageType'           => "machine",
-            'isPublic'            => true,
-            'platform'            => "windows",
-            'productCodes'        => [],
-            'rootDeviceName'      => "/dev/sda1",
-            'rootDeviceType'      => "ebs",
-            'stateReason'         => {},
-            'tagSet'              => {},
-            'virtualizationType'  => "hvm"
-          }, {
-            'architecture'        => "i386",
-            'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
-                                       "snapshotId"=>"snap-f7e645f4",
-                                       "volumeSize"=>10,
-                                       "deleteOnTermination"=>"true",
-                                       "volumeType"=>"standard",
-                                       "encrypted"=>"false"}],
-            'description'         => "DC for Quan",
-            'hypervisor'          => "xen",
-            'imageId'             => "ami-4ace6d21",
-            'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
-            'imageOwnerAlias'     => "microsoft",
-            'name'                => "ubuntu i386",
-            'imageOwnerId'        => "461346954234",
-            'imageState'          => "available",
-            'imageType'           => "machine",
-            'isPublic'            => true,
-            'productCodes'        => [],
-            'rootDeviceName'      => "/dev/sda1",
-            'rootDeviceType'      => "ebs",
-            'stateReason'         => {},
-            'tagSet'              => {},
-            'virtualizationType'  => "hvm"
-          }, {
-            'architecture'        => "x86_64",
-            'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
-                                       "snapshotId"=>"snap-f7e645f4",
-                                       "volumeSize"=>8,
-                                       "deleteOnTermination"=>"true",
-                                       "volumeType"=>"standard",
-                                       "encrypted"=>"false"}],
-            'description'         => "DC for Quan",
-            'hypervisor'          => "xen",
-            'imageId'             => "ami-4ace6d29",
-            'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
-            'imageOwnerAlias'     => "microsoft",
-            'name'                => "fedora i64",
-            'imageOwnerId'        => "461346954234",
-            'imageState'          => "available",
-            'imageType'           => "machine",
-            'isPublic'            => true,
-            'productCodes'        => [],
-            'rootDeviceName'      => "/dev/sda1",
-            'rootDeviceType'      => "ebs",
-            'stateReason'         => {},
-            'tagSet'              => {},
-            'virtualizationType'  => "hvm"
-          }],
-        'requestId'     => "ba38c315-f1b4-4822-b336-6309bed6d50c"
-        }
-      )
-    end
+    describe '#run' do
+      let(:knife_ec2_ami_list) { Chef::Knife::Ec2AmiList.new }
+      let(:ec2_connection) { double(Fog::Compute::AWS) }
+      before (:each) do
+        allow(knife_ec2_ami_list).to receive(:connection).and_return(ec2_connection)
+        @describe_images_format = double("describe_image_output", :body => { 
+              'imagesSet'    => [{
+              'architecture'        => "x86_64",
+              'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
+                                         "snapshotId"=>"snap-f7e645f4",
+                                         "volumeSize"=>30,
+                                         "deleteOnTermination"=>"true",
+                                         "volumeType"=>"standard",
+                                         "encrypted"=>"false"}],
+              'description'         => "DC for Quan",
+              'hypervisor'          => "xen",
+              'imageId'             => "ami-4ace6d23",
+              'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
+              'imageOwnerAlias'     => "microsoft",
+              'name'                => "Windows_Server-2008-R2-SP1-English-64Bit-Windows_Media_Services_4.1-2012.06.12",
+              'imageOwnerId'        => "461346954234",
+              'imageState'          => "available",
+              'imageType'           => "machine",
+              'isPublic'            => true,
+              'platform'            => "windows",
+              'productCodes'        => [],
+              'rootDeviceName'      => "/dev/sda1",
+              'rootDeviceType'      => "ebs",
+              'stateReason'         => {},
+              'tagSet'              => {},
+              'virtualizationType'  => "hvm"
+            }, {
+              'architecture'        => "i386",
+              'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
+                                         "snapshotId"=>"snap-f7e645f4",
+                                         "volumeSize"=>10,
+                                         "deleteOnTermination"=>"true",
+                                         "volumeType"=>"standard",
+                                         "encrypted"=>"false"}],
+              'description'         => "DC for Quan",
+              'hypervisor'          => "xen",
+              'imageId'             => "ami-4ace6d21",
+              'imageOwnerAlias'     => "aws-marketplace",
+              'name'                => "ubuntu i386",
+              'imageOwnerId'        => "461346954235",
+              'imageState'          => "available",
+              'imageType'           => "machine",
+              'isPublic'            => true,
+              'productCodes'        => [],
+              'rootDeviceName'      => "/dev/sda1",
+              'rootDeviceType'      => "ebs",
+              'stateReason'         => {},
+              'tagSet'              => {},
+              'virtualizationType'  => "hvm"
+            }, {
+              'architecture'        => "x86_64",
+              'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
+                                         "snapshotId"=>"snap-f7e645f4",
+                                         "volumeSize"=>8,
+                                         "deleteOnTermination"=>"true",
+                                         "volumeType"=>"standard",
+                                         "encrypted"=>"false"}],
+              'description'         => "DC for Quan",
+              'hypervisor'          => "xen",
+              'imageId'             => "ami-4ace6d29",
+              'imageOwnerAlias'     => "aws-marketplace",
+              'name'                => "fedora i64",
+              'imageOwnerId'        => "461346954234",
+              'imageState'          => "available",
+              'imageType'           => "machine",
+              'isPublic'            => true,
+              'productCodes'        => [],
+              'rootDeviceName'      => "/dev/sda1",
+              'rootDeviceType'      => "ebs",
+              'stateReason'         => {},
+              'tagSet'              => {},
+              'virtualizationType'  => "hvm"
+            }],
+          'requestId'     => "ba38c315-f1b4-4822-b336-6309bed6d50c"
+          }
+        )
+      end
 
-    it 'invokes validate!' do
-      allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-      allow(knife_ec2_ami_list.ui).to receive(:warn)
-      expect(knife_ec2_ami_list).to receive(:validate!)
-      knife_ec2_ami_list.run
-    end
-
-    context 'when region is not specified' do
-      it 'shows warning that default region will be will be used' do
-        knife_ec2_ami_list.config.delete(:region)
-        Chef::Config[:knife].delete(:region)
-        ec2_servers = double()
+      it 'invokes validate!' do
         allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-        allow(knife_ec2_ami_list).to receive(:validate!)
-        expect(knife_ec2_ami_list.ui).to receive(:warn).with("No region was specified in knife.rb or as an argument. The default region, us-east-1, will be used:")
+        allow(knife_ec2_ami_list.ui).to receive(:warn)
+        expect(knife_ec2_ami_list).to receive(:validate!)
         knife_ec2_ami_list.run
       end
-    end
 
-    context 'when --owner is passed' do
-      before do
-        allow(knife_ec2_ami_list.ui).to receive(:warn)
-        allow(knife_ec2_ami_list).to receive(:custom_warnings!)
-      end
-
-      context 'When value for owner is nil' do
-        it 'shows the available AMIs List' do
-          knife_ec2_ami_list.config[:owner] = nil
+      context 'when region is not specified' do
+        it 'shows warning that default region will be will be used' do
+          knife_ec2_ami_list.config.delete(:region)
+          Chef::Config[:knife].delete(:region)
+          ec2_servers = double()
           allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          allow(knife_ec2_ami_list).to receive(:validate!)
+          expect(knife_ec2_ami_list.ui).to receive(:warn).with("No region was specified in knife.rb or as an argument. The default region, us-east-1, will be used:")
           knife_ec2_ami_list.run
         end
       end
 
-      context 'When value for owner is self' do
-        it 'shows the private AMIs List' do
-          knife_ec2_ami_list.config[:owner] = self
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
-        end
-      end
-
-      context 'When value for owner is microsoft' do
-        it 'shows the microsoft alias AMIs List' do
-          knife_ec2_ami_list.config[:owner] = 'microsoft'
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
-        end
-      end
-
-      context 'When value for owner is aws-marketplace' do
-        it 'shows the available AMIs List' do
-          knife_ec2_ami_list.config[:owner] = 'aws-marketplace'
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
-        end
-      end
-
-      context 'When owner is invalid' do
-        it 'raises error' do
-          knife_ec2_ami_list.config[:owner] = 'xyz'
+      context 'when --owner is passed' do
+        before do
+          allow(knife_ec2_ami_list.ui).to receive(:warn)
+          allow(knife_ec2_ami_list).to receive(:custom_warnings!)
           knife_ec2_ami_list.config[:use_iam_profile] = true
-          expect{ knife_ec2_ami_list.validate! }.to raise_error "The owner should be self, aws-marketplace or microsoft."
         end
-      end
-    end
 
-    context 'when --platform is passed' do
-      before do
-        allow(knife_ec2_ami_list.ui).to receive(:warn)
-        allow(knife_ec2_ami_list).to receive(:custom_warnings!)
-      end
-
-      context 'When platform is nil' do
-        it 'shows all the AMIs List' do
-          knife_ec2_ami_list.config[:platform] = nil
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
+        context 'When value for owner is nil' do
+          it 'shows the available AMIs List' do
+            knife_ec2_ami_list.config[:owner] = nil
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            expect(knife_ec2_ami_list).to receive(:validate!)
+            images = ec2_connection.describe_images.body['imagesSet']
+            output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+            output_column_count = output_column.length
+            images.each do |image|
+              output_column << image["imageId"].to_s
+              output_column << (image["platform"] ?  image["platform"] : image["name"].split(/\W+/).first)
+              output_column << image["architecture"].to_s
+              output_column << image["blockDeviceMapping"].first["volumeSize"].to_s
+              output_column << image["name"].split(/\W+/).first
+            end
+            expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+            knife_ec2_ami_list.run
+          end
         end
-      end
 
-      context 'When platform is windows' do
-        it 'shows only windows AMIs List' do
-          knife_ec2_ami_list.config[:platform] = 'windows'
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          window_image = ec2_connection.describe_images.body['imagesSet'].first
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column << window_image["imageId"]
-          output_column << window_image["platform"]
-          output_column << window_image["architecture"]
-          output_column << window_image["blockDeviceMapping"].first["volumeSize"].to_s
-          output_column << window_image["name"].split(/\W+/).first
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
+        context 'When value for owner is self' do
+          it 'does not raise any error' do
+            knife_ec2_ami_list.config[:owner] = 'self'
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            expect{ knife_ec2_ami_list.validate! }.not_to raise_error
+          end
         end
-      end
 
-      context 'When platform is ubuntu' do
-        it 'shows only ubuntu AMIs List' do
-          knife_ec2_ami_list.config[:platform] = 'ubuntu'
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          ubuntu_image = ec2_connection.describe_images.body['imagesSet'][1]
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column << ubuntu_image["imageId"]
-          output_column << ubuntu_image["name"].split(/\W+/).first
-          output_column << ubuntu_image["architecture"]
-          output_column << ubuntu_image["blockDeviceMapping"].first["volumeSize"].to_s
-          output_column << ubuntu_image["name"].split(/\W+/).first
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
+        context 'When value for owner is microsoft' do
+          it 'does not raise any error' do
+            knife_ec2_ami_list.config[:owner] = 'microsoft'
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            expect{ knife_ec2_ami_list.validate! }.not_to raise_error
+          end
+        end
+
+        context 'When value for owner is aws-marketplace' do
+          it 'does not raise any error' do
+            knife_ec2_ami_list.config[:owner] = 'aws-marketplace'
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            expect{ knife_ec2_ami_list.validate! }.not_to raise_error
+          end
+        end
+
+        context 'When owner is invalid' do
+          it 'raises error' do
+            knife_ec2_ami_list.config[:owner] = 'xyz'
+            knife_ec2_ami_list.config[:use_iam_profile] = true
+            expect{ knife_ec2_ami_list.validate! }.to raise_error "Invalid owner: #{knife_ec2_ami_list.config[:owner]}. Allowed owners are self, aws-marketplace or microsoft."
+          end
         end
       end
 
-      context 'When platform is fedora' do
-        it 'shows only fedora AMIs List' do
-          knife_ec2_ami_list.config[:platform] = 'fedora'
-          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
-          expect(knife_ec2_ami_list).to receive(:validate!)
-          fedora_image = ec2_connection.describe_images.body['imagesSet'].last
-          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
-          output_column_count = output_column.length
-          output_column << fedora_image["imageId"]
-          output_column << fedora_image["name"].split(/\W+/).first
-          output_column << fedora_image["architecture"]
-          output_column << fedora_image["blockDeviceMapping"].first["volumeSize"].to_s
-          output_column << fedora_image["name"].split(/\W+/).first
-          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
-          knife_ec2_ami_list.run
+      context 'when --platform is passed' do
+        before do
+          allow(knife_ec2_ami_list.ui).to receive(:warn)
+          allow(knife_ec2_ami_list).to receive(:custom_warnings!)
         end
-      end
 
-      context 'When platform is invalid' do
-        it 'raises error' do
-          knife_ec2_ami_list.config[:platform] = 'xyz'
-          knife_ec2_ami_list.config[:use_iam_profile] = true
-          knife_ec2_ami_list.config[:owner] = true
-          expect{ knife_ec2_ami_list.validate! }.to raise_error "The platform should be ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco, amazon, nessus."
+        context 'When platform is nil' do
+          it 'shows all the AMIs List' do
+            knife_ec2_ami_list.config[:platform] = nil
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            images = ec2_connection.describe_images.body['imagesSet']
+            expect(knife_ec2_ami_list).to receive(:validate!)
+            output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+            output_column_count = output_column.length
+            images.each do |image|
+              output_column << image["imageId"].to_s
+              output_column << (image["platform"] ?  image["platform"] : image["name"].split(/\W+/).first)
+              output_column << image["architecture"].to_s
+              output_column << image["blockDeviceMapping"].first["volumeSize"].to_s
+              output_column << image["name"].split(/\W+/).first
+            end
+            expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+            knife_ec2_ami_list.run
+          end
+        end
+
+        context 'When platform is windows' do
+          it 'shows only windows AMIs List' do
+            knife_ec2_ami_list.config[:platform] = 'windows'
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            window_image = ec2_connection.describe_images.body['imagesSet'].first
+            expect(knife_ec2_ami_list).to receive(:validate!)
+            output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+            output_column_count = output_column.length
+            output_column << window_image["imageId"]
+            output_column << window_image["platform"]
+            output_column << window_image["architecture"]
+            output_column << window_image["blockDeviceMapping"].first["volumeSize"].to_s
+            output_column << window_image["name"].split(/\W+/).first
+            expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+            knife_ec2_ami_list.run
+          end
+        end
+
+        context 'When platform is ubuntu' do
+          it 'shows only ubuntu AMIs List' do
+            knife_ec2_ami_list.config[:platform] = 'ubuntu'
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            ubuntu_image = ec2_connection.describe_images.body['imagesSet'][1]
+            expect(knife_ec2_ami_list).to receive(:validate!)
+            output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+            output_column_count = output_column.length
+            output_column << ubuntu_image["imageId"]
+            output_column << ubuntu_image["name"].split(/\W+/).first
+            output_column << ubuntu_image["architecture"]
+            output_column << ubuntu_image["blockDeviceMapping"].first["volumeSize"].to_s
+            output_column << ubuntu_image["name"].split(/\W+/).first
+            expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+            knife_ec2_ami_list.run
+          end
+        end
+
+        context 'When platform is fedora' do
+          it 'shows only fedora AMIs List' do
+            knife_ec2_ami_list.config[:platform] = 'fedora'
+            allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+            expect(knife_ec2_ami_list).to receive(:validate!)
+            fedora_image = ec2_connection.describe_images.body['imagesSet'].last
+            output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+            output_column_count = output_column.length
+            output_column << fedora_image["imageId"]
+            output_column << fedora_image["name"].split(/\W+/).first
+            output_column << fedora_image["architecture"]
+            output_column << fedora_image["blockDeviceMapping"].first["volumeSize"].to_s
+            output_column << fedora_image["name"].split(/\W+/).first
+            expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+            knife_ec2_ami_list.run
+          end
+        end
+
+        context 'When platform is invalid' do
+          it 'raises error' do
+            knife_ec2_ami_list.config[:platform] = 'xyz'
+            knife_ec2_ami_list.config[:use_iam_profile] = true
+            knife_ec2_ami_list.config[:owner] = true
+            expect{ knife_ec2_ami_list.validate! }.to raise_error "Invalid platform: #{knife_ec2_ami_list.config[:platform]}. Allowed platforms are: ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco, amazon, nessus."
+          end
         end
       end
     end
   end
-end

--- a/spec/unit/ec2_ami_list_spec.rb
+++ b/spec/unit/ec2_ami_list_spec.rb
@@ -1,0 +1,275 @@
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path('../../spec_helper', __FILE__)
+require 'fog/aws'
+
+describe Chef::Knife::Ec2AmiList do
+
+  describe '#run' do
+    let(:knife_ec2_ami_list) { Chef::Knife::Ec2AmiList.new }
+    let(:ec2_connection) { double(Fog::Compute::AWS) }
+    before do
+      allow(knife_ec2_ami_list).to receive(:connection).and_return(ec2_connection)
+      @describe_images_format = double("describe_image_output", :body => { 
+            'imagesSet'    => [{
+            'architecture'        => "x86_64",
+            'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
+                                       "snapshotId"=>"snap-f7e645f4",
+                                       "volumeSize"=>30,
+                                       "deleteOnTermination"=>"true",
+                                       "volumeType"=>"standard",
+                                       "encrypted"=>"false"}],
+            'description'         => "DC for Quan",
+            'hypervisor'          => "xen",
+            'imageId'             => "ami-4ace6d23",
+            'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
+            'imageOwnerAlias'     => "microsoft",
+            'name'                => "Windows_Server-2008-R2-SP1-English-64Bit-Windows_Media_Services_4.1-2012.06.12",
+            'imageOwnerId'        => "461346954234",
+            'imageState'          => "available",
+            'imageType'           => "machine",
+            'isPublic'            => true,
+            'platform'            => "windows",
+            'productCodes'        => [],
+            'rootDeviceName'      => "/dev/sda1",
+            'rootDeviceType'      => "ebs",
+            'stateReason'         => {},
+            'tagSet'              => {},
+            'virtualizationType'  => "hvm"
+          }, {
+            'architecture'        => "i386",
+            'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
+                                       "snapshotId"=>"snap-f7e645f4",
+                                       "volumeSize"=>10,
+                                       "deleteOnTermination"=>"true",
+                                       "volumeType"=>"standard",
+                                       "encrypted"=>"false"}],
+            'description'         => "DC for Quan",
+            'hypervisor'          => "xen",
+            'imageId'             => "ami-4ace6d21",
+            'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
+            'imageOwnerAlias'     => "microsoft",
+            'name'                => "ubuntu i386",
+            'imageOwnerId'        => "461346954234",
+            'imageState'          => "available",
+            'imageType'           => "machine",
+            'isPublic'            => true,
+            'productCodes'        => [],
+            'rootDeviceName'      => "/dev/sda1",
+            'rootDeviceType'      => "ebs",
+            'stateReason'         => {},
+            'tagSet'              => {},
+            'virtualizationType'  => "hvm"
+          }, {
+            'architecture'        => "x86_64",
+            'blockDeviceMapping'  => [{"deviceName"=>"/dev/sda1",
+                                       "snapshotId"=>"snap-f7e645f4",
+                                       "volumeSize"=>8,
+                                       "deleteOnTermination"=>"true",
+                                       "volumeType"=>"standard",
+                                       "encrypted"=>"false"}],
+            'description'         => "DC for Quan",
+            'hypervisor'          => "xen",
+            'imageId'             => "ami-4ace6d29",
+            'imageLocation'       => "microsoft/Windows_Server-2008-R2-SP1-English-64Bit-WebMatrix_Hosting-2012.06.12",
+            'imageOwnerAlias'     => "microsoft",
+            'name'                => "fedora i64",
+            'imageOwnerId'        => "461346954234",
+            'imageState'          => "available",
+            'imageType'           => "machine",
+            'isPublic'            => true,
+            'productCodes'        => [],
+            'rootDeviceName'      => "/dev/sda1",
+            'rootDeviceType'      => "ebs",
+            'stateReason'         => {},
+            'tagSet'              => {},
+            'virtualizationType'  => "hvm"
+          }],
+        'requestId'     => "ba38c315-f1b4-4822-b336-6309bed6d50c"
+        }
+      )
+    end
+
+    it 'invokes validate!' do
+      allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+      allow(knife_ec2_ami_list.ui).to receive(:warn)
+      expect(knife_ec2_ami_list).to receive(:validate!)
+      knife_ec2_ami_list.run
+    end
+
+    context 'when region is not specified' do
+      it 'shows warning that default region will be will be used' do
+        knife_ec2_ami_list.config.delete(:region)
+        Chef::Config[:knife].delete(:region)
+        ec2_servers = double()
+        allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+        allow(knife_ec2_ami_list).to receive(:validate!)
+        expect(knife_ec2_ami_list.ui).to receive(:warn).with("No region was specified in knife.rb or as an argument. The default region, us-east-1, will be used:")
+        knife_ec2_ami_list.run
+      end
+    end
+
+    context 'when --owner is passed' do
+      before do
+        allow(knife_ec2_ami_list.ui).to receive(:warn)
+        allow(knife_ec2_ami_list).to receive(:custom_warnings!)
+      end
+
+      context 'When value for owner is nil' do
+        it 'shows the available AMIs List' do
+          knife_ec2_ami_list.config[:owner] = nil
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When value for owner is self' do
+        it 'shows the private AMIs List' do
+          knife_ec2_ami_list.config[:owner] = self
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When value for owner is microsoft' do
+        it 'shows the microsoft alias AMIs List' do
+          knife_ec2_ami_list.config[:owner] = 'microsoft'
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When value for owner is aws-marketplace' do
+        it 'shows the available AMIs List' do
+          knife_ec2_ami_list.config[:owner] = 'aws-marketplace'
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When owner is invalid' do
+        it 'raises error' do
+          knife_ec2_ami_list.config[:owner] = 'xyz'
+          knife_ec2_ami_list.config[:use_iam_profile] = true
+          expect{ knife_ec2_ami_list.validate! }.to raise_error "The owner should be self, aws-marketplace or microsoft."
+        end
+      end
+    end
+
+    context 'when --platform is passed' do
+      before do
+        allow(knife_ec2_ami_list.ui).to receive(:warn)
+        allow(knife_ec2_ami_list).to receive(:custom_warnings!)
+      end
+
+      context 'When platform is nil' do
+        it 'shows all the AMIs List' do
+          knife_ec2_ami_list.config[:platform] = nil
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column += ["ami-4ace6d23", "windows", "x86_64", "30", "Windows_Server", "ami-4ace6d21", "ubuntu", "i386", "10", "ubuntu", "ami-4ace6d29", "fedora", "x86_64", "8", "fedora"]
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When platform is windows' do
+        it 'shows only windows AMIs List' do
+          knife_ec2_ami_list.config[:platform] = 'windows'
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          window_image = ec2_connection.describe_images.body['imagesSet'].first
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column << window_image["imageId"]
+          output_column << window_image["platform"]
+          output_column << window_image["architecture"]
+          output_column << window_image["blockDeviceMapping"].first["volumeSize"].to_s
+          output_column << window_image["name"].split(/\W+/).first
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When platform is ubuntu' do
+        it 'shows only ubuntu AMIs List' do
+          knife_ec2_ami_list.config[:platform] = 'ubuntu'
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          ubuntu_image = ec2_connection.describe_images.body['imagesSet'][1]
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column << ubuntu_image["imageId"]
+          output_column << ubuntu_image["name"].split(/\W+/).first
+          output_column << ubuntu_image["architecture"]
+          output_column << ubuntu_image["blockDeviceMapping"].first["volumeSize"].to_s
+          output_column << ubuntu_image["name"].split(/\W+/).first
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When platform is fedora' do
+        it 'shows only fedora AMIs List' do
+          knife_ec2_ami_list.config[:platform] = 'fedora'
+          allow(ec2_connection).to receive(:describe_images).and_return(@describe_images_format)
+          expect(knife_ec2_ami_list).to receive(:validate!)
+          fedora_image = ec2_connection.describe_images.body['imagesSet'].last
+          output_column = ["AMI ID", "Platform", "Architecture", "Size", "Name"]
+          output_column_count = output_column.length
+          output_column << fedora_image["imageId"]
+          output_column << fedora_image["name"].split(/\W+/).first
+          output_column << fedora_image["architecture"]
+          output_column << fedora_image["blockDeviceMapping"].first["volumeSize"].to_s
+          output_column << fedora_image["name"].split(/\W+/).first
+          expect(knife_ec2_ami_list.ui).to receive(:list).with(output_column,:uneven_columns_across, output_column_count)
+          knife_ec2_ami_list.run
+        end
+      end
+
+      context 'When platform is invalid' do
+        it 'raises error' do
+          knife_ec2_ami_list.config[:platform] = 'xyz'
+          knife_ec2_ami_list.config[:use_iam_profile] = true
+          knife_ec2_ami_list.config[:owner] = true
+          expect{ knife_ec2_ami_list.validate! }.to raise_error "The platform should be ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco, amazon, nessus."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/chef/knife-ec2/issues/313 : Added feature to list your private and public knife ec2 AMIs. Also used filter for specific owner and platform AMI's, like ubuntu, windows, debian etc.