### PR TITLE
Update list of instance_types that support ebs-encryption

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -936,11 +936,14 @@ class Chef
             ui.error("--ebs-encrypted option requires valid flavor to be specified.")
             exit 1
           elsif (locate_config_value(:ebs_encrypted) and ! %w(m3.medium  m3.large  m3.xlarge m3.2xlarge m4.large m4.xlarge
-                                             m4.2xlarge m4.4xlarge m4.10xlarge t2.micro t2.small t2.medium t2.large
-                                             d2.xlarge  d2.2xlarge d2.4xlarge d2.8xlarge c4.large c4.xlarge
-                                             c4.2xlarge c4.4xlarge c4.8xlarge c3.large c3.xlarge c3.2xlarge
-                                             c3.4xlarge c3.8xlarge cr1.8xlarge r3.large r3.xlarge r3.2xlarge
-                                             r3.4xlarge r3.8xlarge i2.xlarge i2.2xlarge i2.4xlarge i2.8xlarge g2.2xlarge g2.8xlarge).include?(locate_config_value(:flavor)))
+                                             m4.2xlarge m4.4xlarge m4.10xlarge m4.16xlarge t2.nano t2.micro t2.small
+                                             t2.medium t2.large t2.xlarge t2.2xlarge d2.xlarge  d2.2xlarge d2.4xlarge
+                                             d2.8xlarge c4.large c4.xlarge c4.2xlarge c4.4xlarge c4.8xlarge c3.large
+                                             c3.xlarge c3.2xlarge c3.4xlarge c3.8xlarge cr1.8xlarge r3.large r3.xlarge
+                                             r3.2xlarge r3.4xlarge r3.8xlarge r4.large r4.xlarge r4.2xlarge r4.4xlarge
+                                             r4.8xlarge r4.16xlarge x1.16xlarge x1.32xlarge i2.xlarge i2.2xlarge i2.4xlarge
+                                             i2.8xlarge i3.large i3.xlarge i3.2xlarge i3.4xlarge i3.8xlarge i3.16xlarge
+                                             f1.2xlarge f1.16xlarge g2.2xlarge g2.8xlarge p2.xlarge p2.8xlarge p2.16xlarge).include?(locate_config_value(:flavor)))
             ui.error("--ebs-encrypted option is not supported for #{locate_config_value(:flavor)} flavor.")
             exit 1
           end


### PR DESCRIPTION
The list of instance types that support ebs-encrypted volumes is missing a lot of instance types. I pulled the list from http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html and updated the list of volumes that support ebs-encryption

Signed-off-by: Cory Stephenson <aevin@me.com>