### PR TITLE
Allow chef 13 as a development dependency

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mime-types'
   s.add_dependency 'knife-windows', '~> 1.0'
 
-  s.add_development_dependency 'chef',  '~> 12.0', '>= 12.2.1'
+  s.add_development_dependency 'chef',  '>= 12.2.1'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rake',  '~> 11.0'
   s.add_development_dependency 'sdoc',  '~> 0.3'


### PR DESCRIPTION
There's no reason to limit this to chef 12