### PR TITLE
require `'rb-readline` to avoid ruby 2.4 warnings about `Fixnum`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rb-readline'
+gem 'rb-readline', '>= 0.5.5'


### PR DESCRIPTION
Example:
```
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/rb-readline-0.5.3/lib/rbreadline.rb:13: warning: constant ::Fixnum is deprecated
```

Signed-off-by: Ben Abrams <me@benabrams.it>