### PR TITLE
Add `--instance-initiated-shutdown-behavior` option

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -454,8 +454,8 @@ class Chef
         :default => false
 
       option :instance_initiated_shutdown_behavior,
-        :long => "--instance-initiated-shutdown-behavior",
-        :descript => "Indicates whether an instance stops or terminates when you initiate shutdown from the instance. Possible values are 'stop' and 'terminate', default is 'stop'."
+        :long => "--instance-initiated-shutdown-behavior STUTDOWN_BEHAVIOR",
+        :description => "Indicates whether an instance stops or terminates when you initiate shutdown from the instance. Possible values are 'stop' and 'terminate', default is 'stop'."
 
       def run
         $stdout.sync = true

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -453,6 +453,10 @@ class Chef
         :boolean => true,
         :default => false
 
+      option :instance_initiated_shutdown_behavior,
+        :long => "--instance-initiated-shutdown-behavior",
+        :descript => "Indicates whether an instance stops or terminates when you initiate shutdown from the instance. Possible values are 'stop' and 'terminate', default is 'stop'."
+
       def run
         $stdout.sync = true
         validate!
@@ -1196,6 +1200,8 @@ EOH
 
         ## cannot pass disable_api_termination option to the API when using spot instances ##
         server_def[:disable_api_termination] = locate_config_value(:disable_api_termination) if locate_config_value(:spot_price).nil?
+
+        server_def[:instance_initiated_shutdown_behavior] = locate_config_value(:instance_initiated_shutdown_behavior)
 
         server_def
       end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -133,7 +133,8 @@ describe Chef::Knife::Ec2ServerCreate do
           :request_type => 'persistent',
           :placement_group => nil,
           :iam_instance_profile_name => nil,
-          :ebs_optimized => "false"
+          :ebs_optimized => "false",
+          :instance_initiated_shutdown_behavior=>nil
         }
       allow(@bootstrap).to receive(:run)
     end


### PR DESCRIPTION
Adds an option in `knife-ec2` to set the `--instance-initiated-shutdown-behavior` with the option to set `"stop"` or `"terminate"`. The default is `"stop"`. 
cheery-pick the contains from PR: https://github.com/chef/knife-ec2/pull/507 .
Made changes as per review comments to work functionality successfully.

Tested with command:
```
knife ec2 server create -N AshTestRHEL7 -I ami-b63769a1 -f t2.micro -S ash_new_key -i  C:\Users\msys\.ssh\ash_new_key.pem --ssh-user ec2-user --region us-east-1 -Z us-east-1a --instance-initiated-shutdown-behavior terminate -r 'recipe[cbk1]' -c 'D:\chef-repo\.chef\knife.rb'
```