### PR TITLE
[MSYS-765]Feature chef-tag & aws-tag option

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -110,8 +110,11 @@ class Chef
       option :tags,
         :short => "-T T=V[,T=V,...]",
         :long => "--tags Tag=Value[,Tag=Value...]",
-        :description => "The tags for this server",
-        :proc => Proc.new { |tags| tags.split(',') }
+        :description => "The tags for this server. [DEPRECATED] Use --aws-tag instead.",
+        :proc => Proc.new { |v|
+          Chef::Log.warn("[DEPRECATED] --tags option is deprecated. Use --aws-tag option instead.")
+          v
+        }
 
       option :availability_zone,
         :short => "-Z ZONE",
@@ -453,7 +456,11 @@ class Chef
 
       option :tag_node_in_chef,
         :long => "--tag-node-in-chef",
-        :description => "Flag for tagging node in ec2 and chef both",
+        :description => "Flag for tagging node in ec2 and chef both. [DEPRECATED] Use --chef-tag instead.",
+        :proc        => Proc.new { |v|
+          Chef::Log.warn("[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead.")
+          v
+        },
         :boolean => true,
         :default => false
 
@@ -462,12 +469,21 @@ class Chef
         :description => "Indicates whether an instance stops or terminates when you initiate shutdown from the instance. Possible values are 'stop' and 'terminate', default is 'stop'."
 
       option :chef_tag,
-        :long => "--chef-tag TAG",
+        :long => "--chef-tag CHEF_TAG",
         :description => "The Chef tag for this server; Use the --chef-tag option multiple times when specifying multiple tags e.g. --chef-tag tag1 --chef-tag tag2.",
         :proc => Proc.new { |chef_tag|
           Chef::Config[:knife][:chef_tag] ||= []
           Chef::Config[:knife][:chef_tag].push(chef_tag)
           Chef::Config[:knife][:chef_tag]
+        }
+
+      option :aws_tag,
+        :long => "--aws-tag AWS_TAG",
+        :description => "AWS tag for this server; Use the --aws-tag option multiple times when specifying multiple tags e.g. --aws-tag key1=value1 --aws-tag key2=value2.",
+        :proc => Proc.new { |aws_tag|
+          Chef::Config[:knife][:aws_tag] ||= []
+          Chef::Config[:knife][:aws_tag].push(aws_tag)
+          Chef::Config[:knife][:aws_tag]
         }
 
       def run
@@ -536,7 +552,7 @@ class Chef
           end
         end
 
-        printed_tags = hashed_tags.map{ |tag, val| "#{tag}: #{val}" }.join(", ")
+        printed_aws_tags = hashed_tags.map{ |tag, val| "#{tag}: #{val}" }.join(", ")
 
         hashed_volume_tags={}
         volume_tags = locate_config_value(:volume_tags)
@@ -563,7 +579,7 @@ class Chef
 
         msg_pair("IAM Profile", locate_config_value(:iam_instance_profile))
 
-        msg_pair("Tags", printed_tags)
+        msg_pair("AWS Tags", printed_aws_tags)
         msg_pair("Volume Tags", printed_volume_tags)
         msg_pair("SSH Key", @server.key_name)
 
@@ -650,7 +666,7 @@ class Chef
         msg_pair("Security Group Ids", printed_security_group_ids) if vpc_mode? or @server.security_group_ids
         msg_pair("IAM Profile", locate_config_value(:iam_instance_profile)) if locate_config_value(:iam_instance_profile)
         msg_pair("Primary ENI", locate_config_value(:primary_eni)) if locate_config_value(:primary_eni)
-        msg_pair("Tags", printed_tags)
+        msg_pair("AWS Tags", printed_aws_tags)
         msg_pair("Chef Tags", locate_config_value(:chef_tag)) if locate_config_value(:chef_tag)
         msg_pair("SSH Key", @server.key_name)
         msg_pair("Root Device Type", @server.root_device_type)
@@ -1019,9 +1035,9 @@ class Chef
       end
 
       def tags
-       tags = locate_config_value(:tags)
+       tags = locate_config_value(:aws_tag)
         if !tags.nil? and tags.length != tags.to_s.count('=')
-          ui.error("Tags should be entered in a key = value pair")
+          ui.error("AWS Tags should be entered in a key = value pair")
           exit 1
         end
        tags

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -461,6 +461,15 @@ class Chef
         :long => "--instance-initiated-shutdown-behavior SHUTDOWN_BEHAVIOR",
         :description => "Indicates whether an instance stops or terminates when you initiate shutdown from the instance. Possible values are 'stop' and 'terminate', default is 'stop'."
 
+      option :chef_tag,
+        :long => "--chef-tag TAG",
+        :description => "The Chef tag for this server; Use the --chef-tag option multiple times when specifying multiple tags e.g. --chef-tag tag1 --chef-tag tag2.",
+        :proc => Proc.new { |chef_tag|
+          Chef::Config[:knife][:chef_tag] ||= []
+          Chef::Config[:knife][:chef_tag].push(chef_tag)
+          Chef::Config[:knife][:chef_tag]
+        }
+
       def run
         $stdout.sync = true
         validate!
@@ -642,6 +651,7 @@ class Chef
         msg_pair("IAM Profile", locate_config_value(:iam_instance_profile)) if locate_config_value(:iam_instance_profile)
         msg_pair("Primary ENI", locate_config_value(:primary_eni)) if locate_config_value(:primary_eni)
         msg_pair("Tags", printed_tags)
+        msg_pair("Chef Tags", locate_config_value(:chef_tag)) if locate_config_value(:chef_tag)
         msg_pair("SSH Key", @server.key_name)
         msg_pair("Root Device Type", @server.root_device_type)
         msg_pair("Root Volume Tags", printed_volume_tags)
@@ -817,6 +827,7 @@ class Chef
         bootstrap.config[:install_as_service] = locate_config_value(:install_as_service)
         bootstrap.config[:session_timeout] = locate_config_value(:session_timeout)
         bootstrap.config[:tags] = config[:tags] if locate_config_value(:tag_node_in_chef)
+        bootstrap.config[:tags] = config[:chef_tag] if locate_config_value(:chef_tag)
 
         if locate_config_value(:chef_node_name)
           bootstrap.config[:chef_node_name] = evaluate_node_name(locate_config_value(:chef_node_name))
@@ -835,6 +846,7 @@ class Chef
         bootstrap.config[:ssh_gateway] = config[:ssh_gateway]
         bootstrap.config[:identity_file] = config[:identity_file]
         bootstrap.config[:tags] = config[:tags] if locate_config_value(:tag_node_in_chef)
+        bootstrap.config[:tags] = config[:chef_tag] if locate_config_value(:chef_tag)
 
         if locate_config_value(:chef_node_name)
           bootstrap.config[:chef_node_name] = evaluate_node_name(locate_config_value(:chef_node_name))
@@ -1219,7 +1231,7 @@ EOH
         server_def[:disable_api_termination] = locate_config_value(:disable_api_termination) if locate_config_value(:spot_price).nil?
 
         server_def[:instance_initiated_shutdown_behavior] = locate_config_value(:instance_initiated_shutdown_behavior)
-
+        server_def[:chef_tag] = locate_config_value(:chef_tag)
         server_def
       end
 

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -470,7 +470,7 @@ class Chef
 
       option :chef_tag,
         :long => "--chef-tag CHEF_TAG",
-        :description => "Used to tag the node in chef server; Provide --chef-tag option multiple times when specifying multiple tags e.g. --chef-tag tag1 --chef-tag tag2.",
+        :description => "Use to tag the node in chef server; Provide --chef-tag option multiple times when specifying multiple tags e.g. --chef-tag tag1 --chef-tag tag2.",
         :proc => Proc.new { |chef_tag|
           Chef::Config[:knife][:chef_tag] ||= []
           Chef::Config[:knife][:chef_tag].push(chef_tag)

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -470,7 +470,7 @@ class Chef
 
       option :chef_tag,
         :long => "--chef-tag CHEF_TAG",
-        :description => "The Chef tag for this server; Use the --chef-tag option multiple times when specifying multiple tags e.g. --chef-tag tag1 --chef-tag tag2.",
+        :description => "Used to tag the node in chef server; Provide --chef-tag option multiple times when specifying multiple tags e.g. --chef-tag tag1 --chef-tag tag2.",
         :proc => Proc.new { |chef_tag|
           Chef::Config[:knife][:chef_tag] ||= []
           Chef::Config[:knife][:chef_tag].push(chef_tag)
@@ -797,6 +797,7 @@ class Chef
         bootstrap.config[:bootstrap_vault_item] = locate_config_value(:bootstrap_vault_item)
         bootstrap.config[:use_sudo_password] = locate_config_value(:use_sudo_password)
         bootstrap.config[:yes] = locate_config_value(:yes)
+        bootstrap.config[:tags] = config[:chef_tag] if locate_config_value(:chef_tag)
         # Modify global configuration state to ensure hint gets set by
         # knife-bootstrap
         Chef::Config[:knife][:hints] ||= {}
@@ -843,7 +844,6 @@ class Chef
         bootstrap.config[:install_as_service] = locate_config_value(:install_as_service)
         bootstrap.config[:session_timeout] = locate_config_value(:session_timeout)
         bootstrap.config[:tags] = config[:tags] if locate_config_value(:tag_node_in_chef)
-        bootstrap.config[:tags] = config[:chef_tag] if locate_config_value(:chef_tag)
 
         if locate_config_value(:chef_node_name)
           bootstrap.config[:chef_node_name] = evaluate_node_name(locate_config_value(:chef_node_name))
@@ -862,7 +862,6 @@ class Chef
         bootstrap.config[:ssh_gateway] = config[:ssh_gateway]
         bootstrap.config[:identity_file] = config[:identity_file]
         bootstrap.config[:tags] = config[:tags] if locate_config_value(:tag_node_in_chef)
-        bootstrap.config[:tags] = config[:chef_tag] if locate_config_value(:chef_tag)
 
         if locate_config_value(:chef_node_name)
           bootstrap.config[:chef_node_name] = evaluate_node_name(locate_config_value(:chef_node_name))

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1031,6 +1031,9 @@ class Chef
           end
         end
 
+        if locate_config_value(:tag_node_in_chef)
+          ui.warn("[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead.")
+        end
       end
 
       def tags

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -134,7 +134,8 @@ describe Chef::Knife::Ec2ServerCreate do
           :placement_group => nil,
           :iam_instance_profile_name => nil,
           :ebs_optimized => "false",
-          :instance_initiated_shutdown_behavior => nil
+          :instance_initiated_shutdown_behavior => nil,
+          :chef_tag => nil
         }
       allow(@bootstrap).to receive(:run)
     end
@@ -477,7 +478,7 @@ describe Chef::Knife::Ec2ServerCreate do
     end
 
     it "sets the Name tag to the specified name when given --tags Name=NAME" do
-      knife_ec2_create.config[:tags] = ["Name=bobcat"]
+      knife_ec2_create.config[:aws_tag] = ["Name=bobcat"]
       expect(ec2_connection.tags).to receive(:create).with(:key => "Name",
                                                         :value => "bobcat",
                                                         :resource_id => new_ec2_server.id)
@@ -485,7 +486,7 @@ describe Chef::Knife::Ec2ServerCreate do
     end
 
     it "sets arbitrary tags" do
-      knife_ec2_create.config[:tags] = ["foo=bar"]
+      knife_ec2_create.config[:aws_tag] = ["foo=bar"]
       expect(ec2_connection.tags).to receive(:create).with(:key => "foo",
                                                         :value => "bar",
                                                         :resource_id => new_ec2_server.id)

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -477,7 +477,7 @@ describe Chef::Knife::Ec2ServerCreate do
       knife_ec2_create.run
     end
 
-    it "sets the Name tag to the specified name when given --tags Name=NAME" do
+    it "sets the Name tag to the specified name when given --aws-tag Name=NAME" do
       knife_ec2_create.config[:aws_tag] = ["Name=bobcat"]
       expect(ec2_connection.tags).to receive(:create).with(:key => "Name",
                                                         :value => "bobcat",
@@ -485,7 +485,7 @@ describe Chef::Knife::Ec2ServerCreate do
       knife_ec2_create.run
     end
 
-    it "sets arbitrary tags" do
+    it "sets arbitrary aws tags" do
       knife_ec2_create.config[:aws_tag] = ["foo=bar"]
       expect(ec2_connection.tags).to receive(:create).with(:key => "foo",
                                                         :value => "bar",
@@ -2571,7 +2571,7 @@ netstat > c:\\netstat_data.txt
       end
     end
   end
-   ## Add chef tag spec
+
   describe '--chef-tag option' do
     before do
       allow(Fog::Compute::AWS).to receive(:new).and_return(ec2_connection)

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2570,6 +2570,28 @@ netstat > c:\\netstat_data.txt
       end
     end
   end
+   ## Add chef tag spec
+  describe '--chef-tag option' do
+    before do
+      allow(Fog::Compute::AWS).to receive(:new).and_return(ec2_connection)
+    end
+
+    context 'when mulitple values provided from cli for e.g. --chef-tag "foo" --chef-tag "bar"' do
+      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--chef-tag', 'foo', '--chef-tag', 'bar'])}
+      it 'creates array of chef tag' do
+        server_def = ec2_server_create.create_server_def
+        expect(server_def[:chef_tag]).to eq(['foo', 'bar'])
+      end
+    end
+
+    context 'when single value provided from cli for e.g. --chef-tag foo' do
+      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--chef-tag', 'foo'])}
+      it 'creates array of chef tag' do
+        server_def = ec2_server_create.create_server_def
+        expect(server_def[:chef_tag]).to eq(['foo'])
+      end
+    end
+  end
 
   describe 'evaluate_node_name' do
     before do

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2624,8 +2624,8 @@ netstat > c:\\netstat_data.txt
     context 'when provided from cli for e.g. --tag-node-in-chef' do
       let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--tag-node-in-chef'])}
       it 'raises deprecated warning "[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead."' do
-        server_def = ec2_server_create.config
-        expect(server_def[:tag_node_in_chef]).to eq(true)
+        expect(ec2_server_create.ui).to receive(:warn).with("[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead.")
+        ec2_server_create.validate!
       end
     end
   end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2594,6 +2594,42 @@ netstat > c:\\netstat_data.txt
     end
   end
 
+  describe '--aws-tag option' do
+    before do
+      allow(Fog::Compute::AWS).to receive(:new).and_return(ec2_connection)
+    end
+
+    context 'when mulitple values provided from cli for e.g. --aws-tag "foo=bar" --aws-tag "foo1=bar1"' do
+      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--aws-tag', 'foo=bar', '--aws-tag', 'foo1=bar1'])}
+      it 'creates array of aws tag' do
+        server_def = ec2_server_create.config
+        expect(server_def[:aws_tag]).to eq(['foo=bar', 'foo1=bar1'])
+      end
+    end
+
+    context 'when single value provided from cli for e.g. --aws-tag foo=bar' do
+      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--aws-tag', 'foo=bar'])}
+      it 'creates array of aws tag' do
+        server_def = ec2_server_create.config
+        expect(server_def[:aws_tag]).to eq(['foo=bar'])
+      end
+    end
+  end
+
+  describe '--tag-node-in-chef option' do
+    before do
+      allow(Fog::Compute::AWS).to receive(:new).and_return(ec2_connection)
+    end
+
+    context 'when provided from cli for e.g. --tag-node-in-chef' do
+      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(['--tag-node-in-chef'])}
+      it 'raises deprecated warning "[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead."' do
+        server_def = ec2_server_create.config
+        expect(server_def[:tag_node_in_chef]).to eq(true)
+      end
+    end
+  end
+
   describe 'evaluate_node_name' do
     before do
       knife_ec2_create.instance_variable_set(:@server, server)


### PR DESCRIPTION
# Description
`--aws-tag` and `--chef-tag` options are added for tagging EC2 instance in AWS and Chef separately.
# Deprecations
`--tags` option is now deprecated and we are going to use `--aws-tag` for EC2 tags e.g. `--aws-tag <key1=value1>`
`--tag-node-in-chef` is deprecated and we are going to use `--chef-tag` for Chef Tag e.g. `--chef-tag <myTag>` 
# Issues Resolved
Fixes https://github.com/chef/knife-ec2/issues/509