### PR TITLE
MSYS-798 - Fixes for windows administrator password

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1536,13 +1536,14 @@ EOH
       def windows_password
         if not locate_config_value(:winrm_password)
           if locate_config_value(:identity_file)
-            print "\n#{ui.color("Waiting for Windows Admin password to be available", :magenta)}"
-            print(".\n") unless @server
-            if @server && check_windows_password_available(@server.id)
-              puts("done")
+            if @server
+              print "\n#{ui.color("Waiting for Windows Admin password to be available: ", :magenta)}"
+              print(".") until check_windows_password_available(@server.id) { puts("done") }
               response = connection.get_password_data(@server.id)
               data = File.read(locate_config_value(:identity_file))
               config[:winrm_password] = decrypt_admin_password(response.body["passwordData"], data)
+            else
+              print "\n#{ui.color("Fetchig instance details: \n", :magenta)}"
             end
           else
             ui.error("Cannot find SSH Identity file, required to fetch dynamically generated password")

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1537,12 +1537,13 @@ EOH
         if not locate_config_value(:winrm_password)
           if locate_config_value(:identity_file)
             print "\n#{ui.color("Waiting for Windows Admin password to be available", :magenta)}"
-            print(".") until check_windows_password_available(@server.id) {
+            print(".\n") unless @server
+            if @server && check_windows_password_available(@server.id)
               puts("done")
-            }
-            response = connection.get_password_data(@server.id)
-            data = File.read(locate_config_value(:identity_file))
-            config[:winrm_password] = decrypt_admin_password(response.body["passwordData"], data)
+              response = connection.get_password_data(@server.id)
+              data = File.read(locate_config_value(:identity_file))
+              config[:winrm_password] = decrypt_admin_password(response.body["passwordData"], data)
+            end
           else
             ui.error("Cannot find SSH Identity file, required to fetch dynamically generated password")
             exit 1


### PR DESCRIPTION
**Description:**
While Bootstrapping an Amazon node with chef on Windows over SSL `--winrm-transport ssl` fails because we check created instance id which did not exist at that time for administrator user password.

**Solution:**
Updated code so that until instance is created we won't call `check_windows_password_available` method for Administrator's password.

**Command:**
```
knife ec2 server create --node-name excel-dev-ssl --ebs-size 128 --flavor t2.micro --region us-east-1 --subnet subnet-xxxxxx --image ami-ac8156d1 --security-group-id sg-xxxxxx --security-group-id sg-xxxxxxxx --security-group-id sg-xxxxxx -x 'Administrator' --ssh-key aws-key  --user-data bootstrapwinchefnodeamazon3.ps1 --winrm-transport ssl --winrm-ssl-verify-mode verify_none –p 5986 -VV
```

**Issue fixed:**
Bootstrap fails when using `--winrm-transport ssl`  `--winrm-ssl-verify-mode verify_none`. 
Ref: https://github.com/chef/knife-ec2/issues/521

Fixes https://github.com/chef/knife-ec2/issues/521

Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>