### PR TITLE
[MSYS-824] fix breaking tag changes & deprecation warning

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -111,7 +111,10 @@ class Chef
         :short => "-T T=V[,T=V,...]",
         :long => "--tags Tag=Value[,Tag=Value...]",
         :description => "The tags for this server. [DEPRECATED] Use --aws-tag instead.",
-        :proc => Proc.new { |tags| tags.split(',') }
+        :proc => Proc.new { |tags|
+          Chef::Log.warn("[DEPRECATED] --tags option is deprecated. Use --aws-tag option instead.")
+          tags.split(',')
+        }
 
       option :availability_zone,
         :short => "-Z ZONE",
@@ -794,8 +797,11 @@ class Chef
         bootstrap.config[:bootstrap_vault_item] = locate_config_value(:bootstrap_vault_item)
         bootstrap.config[:use_sudo_password] = locate_config_value(:use_sudo_password)
         bootstrap.config[:yes] = locate_config_value(:yes)
+        # If --chef-tag is provided then it will be set in chef as single value e.g. --chef-tag "myTag"
+        # Otherwise if --tag-node-in-chef is provided then it will tag the chef in key=value pair of --tags option
+        # e.g. --tags "key=value"
         if locate_config_value(:chef_tag)
-          bootstrap.config[:tags] = config[:chef_tag]
+          bootstrap.config[:tags] = locate_config_value(:chef_tag)
         elsif locate_config_value(:tag_node_in_chef)
           bootstrap.config[:tags] = config[:tags]
         end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -493,6 +493,31 @@ describe Chef::Knife::Ec2ServerCreate do
       knife_ec2_create.run
     end
 
+    it "sets the Name tag to the specified name when given --tags Name=NAME" do
+      knife_ec2_create.config[:tags] = ["Name=bobcat"]
+      expect(ec2_connection.tags).to receive(:create).with(:key => "Name",
+                                                        :value => "bobcat",
+                                                        :resource_id => new_ec2_server.id)
+      knife_ec2_create.run
+    end
+
+    it "sets arbitrary tags" do
+      knife_ec2_create.config[:tags] = ["foo=bar"]
+      expect(ec2_connection.tags).to receive(:create).with(:key => "foo",
+                                                        :value => "bar",
+                                                        :resource_id => new_ec2_server.id)
+      knife_ec2_create.run
+    end
+
+    it 'raises deprecated warning "[DEPRECATED] --tags option is deprecated. Use --aws-tag option instead."' do
+      knife_ec2_create.config[:tags] = ["foo=bar"]
+      expect(ec2_connection.tags).to receive(:create).with(:key => "foo",
+                                                      :value => "bar",
+                                                      :resource_id => new_ec2_server.id)
+      expect(knife_ec2_create.ui).to receive(:warn).with("[DEPRECATED] --tags option is deprecated. Use --aws-tag option instead.").exactly(2).times
+      knife_ec2_create.validate!
+      knife_ec2_create.run
+    end
   end
 
   describe "when setting volume tags" do


### PR DESCRIPTION
### Description
`--tags` flag was being used with `--tag-node-in-chef` in 0.17.0 and earlier. Deprecation warnings were added in 0.18.0. However deprecation warnings are warnings that suggest while the flags are on the way out, but with an expectation that they still function:
```
WARN: [DEPRECATED] --tags option is deprecated. Use --aws-tag option instead.
WARN: [DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead.
```

### Resolved Issue
https://github.com/chef/knife-ec2/issues/526 