### PR TITLE
Provide a unique console color for us-east-1f availability zone

### DIFF
--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -57,6 +57,8 @@ class Chef
           color = :red
         when /d$/
           color = :magenta
+        when /e$/
+          color = :yellow
         else
           color = :cyan
         end


### PR DESCRIPTION
Previously us-east-1e and us-east-1f would be using the same color.

Signed-off-by: Tim Smith <tsmith@chef.io>