### PR TITLE
Allow for fog-aws 1.0 - 3.0

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.required_ruby_version = ">= 2.3"
 
-  s.add_dependency "fog-aws", "~> 1.0"
+  s.add_dependency "fog-aws", ">= 1", "< 4"
   s.add_dependency "mime-types"
   s.add_dependency "knife-windows", "~> 1.0"
 


### PR DESCRIPTION
Give a range so this still works with older DK releases

Signed-off-by: Tim Smith <tsmith@chef.io>