### PR TITLE
Remove executables from gemspec and cleanup test files

### DIFF
--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
   s.license      = "Apache-2.0"
 
   s.files        = `git ls-files`.split("\n")
-  s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.test_files   = `git ls-files spec/*`.split("\n")
   s.required_ruby_version = ">= 2.3"
 
   s.add_dependency "fog-aws", ">= 1", "< 4"


### PR DESCRIPTION
We only have specs in this repo and knife plugins never have binaries so this whole thing was unnecessary.

Signed-off-by: Tim Smith <tsmith@chef.io>