### PR TITLE
Do not print out a literal \n when deleting servers from ec2

### DIFF
--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -88,7 +88,7 @@ class Chef
             msg_pair("Private DNS Name", @server.private_dns_name)
             msg_pair("Private IP Address", @server.private_ip_address)
 
-            puts '\n'
+            puts "\n"
             confirm("Do you really want to delete this server")
 
             @server.destroy


### PR DESCRIPTION
### Description

This fixes the output from `knife ec2 server delete` whereby currently it prints a literal `\n` to the output stream; when really a newline seems to be what was intended.

### Check List

- ~~[ ] New functionality includes tests~~ N/A
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
