### PR TITLE
Add allow_long_password knife.rb setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The `knife ec2 server create` command also supports the following options for bo
 :kerberos_keytab_file          The Kerberos keytab file used for authentication
 :kerberos_realm                The Kerberos realm used for authentication
 :kerberos_service              The Kerberos service used for authentication
+:allow_long_password           Defaults to false, warns and prompts about WinRM passwords longer than 14 characters
 ```
 ### `knife ec2 ami list`
 

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1005,14 +1005,18 @@ class Chef
         end
 
         if locate_config_value(:winrm_password).to_s.length > 14
-          ui.warn("The password provided is longer than 14 characters. Computers with Windows prior to Windows 2000 will not be able to use this account. Do you want to continue this operation? (Y/N):")
-          password_promt = STDIN.gets.chomp.upcase
-          if password_promt == "N"
-            raise "Exiting as operation with password greater than 14 characters not accepted"
-          elsif password_promt == "Y"
+          if locate_config_value(:allow_long_password)
             @allow_long_password = "/yes"
           else
-            raise "The input provided is incorrect."
+            ui.warn("The password provided is longer than 14 characters and allow_long_password is not set to true in knife.rb. Computers with Windows prior to Windows 2000 will not be able to use this account. Do you want to continue this operation? (Y/N):")
+            password_prompt = STDIN.gets.chomp.upcase
+            if password_prompt == "N"
+              raise "Exiting as operation with password greater than 14 characters not accepted"
+            elsif password_prompt == "Y"
+              @allow_long_password = "/yes"
+            else
+              raise "The input provided is incorrect."
+            end
           end
         end
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2712,7 +2712,17 @@ describe Chef::Knife::Ec2ServerCreate do
       end
     end
 
+    context "allow_long_password is passed in knife config" do
+      before do
+        Chef::Config[:knife][:allow_long_password] = true
+      end
+      it "user addition command is executed forcefully" do
+        knife_ec2_create.validate!
+        expect(knife_ec2_create.instance_variable_get(:@allow_long_password)).to eq ("/yes")
+      end
+    end
   end
+
   describe "--primary_eni option" do
     before do
       allow(Fog::Compute::AWS).to receive(:new).and_return(ec2_connection)


### PR DESCRIPTION
Signed-off-by: Matt Kasa <mkasa@baent.net>

### Description

Allows launching EC2 Windows nodes using passwords longer than 14 characters without being prompted for input. Default behavior is maintained the way it currently works, this just allows people relying on automation to run knife ec2 server create without interaction being required.

### Issues Resolved

https://github.com/chef/knife-ec2/issues/470

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
