### PR TITLE
Update codeowners, test on latest ruby releases + more misc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 
 *               @chef/msys-developers
 .expeditor/**   @chef/jex-team
+README.md       @chef/docs-team

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Issues Resolved
 
 [List any existing issues this PR resolves, or any Discourse or
-StackOverflow discussion that's relevant]
+StackOverflow discussions that are relevant]
 
 ### Check List
 

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
+--format documentation
 --color
--fd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 sudo: false
 language: ruby
 cache: bundler
+dist: xenial
 
 matrix:
   include:
-    - rvm: 2.3.7
-    - rvm: 2.4.4
-    - rvm: 2.5.1
+    - rvm: 2.3.8
+    - rvm: 2.4.5
+    - rvm: 2.5.3
+    - rvm: 2.6
     - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
 
 branches:
   only:
-  - master
+    - master
 
 bundler_args: --jobs 7 --without docs debug
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 begin
@@ -8,8 +7,6 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
-
-Bundler::GemHelper.install_tasks
 
 desc "Run specs"
 RSpec::Core::RakeTask.new(:spec) do |spec|


### PR DESCRIPTION
Also remove the rake tasks for releasing the gem since we do this in
expeditor now.

Signed-off-by: Tim Smith <tsmith@chef.io>