### PR TITLE
Fix ssh connect issue to nix machines

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -33,6 +33,7 @@ class Chef
         require "tempfile"
         require "uri"
         require "chef/knife/bootstrap"
+        require "net/ssh"
         Chef::Knife::Bootstrap.load_deps
       end
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

This is fixing issue for ssh connections to the VM which is being created with `knife ec2  server create` with `current chef v15` installed in workstation.

### Issues Resolved

Fixes https://github.com/chef/knife-ec2/issues/567

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG