### PR TITLE
Prepare for v1 to support chef-15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ dist: xenial
 
 matrix:
   include:
-    - rvm: 2.3.8
-    - rvm: 2.4.5
-    - rvm: 2.5.3
-    - rvm: 2.6
+    - rvm: 2.5.5
+    - rvm: 2.6.3
     - rvm: ruby-head
   allow_failures:
     - rvm: ruby-head
@@ -15,6 +13,7 @@ matrix:
 branches:
   only:
     - master
+    - 0-stable
 
 bundler_args: --jobs 7 --without docs debug
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ group :debug do
 end
 
 group :test do
-  gem "chef", ">= 13.0"
-  gem "chefstyle", "= 0.10.0"
+  gem "chef"
+  gem "chefstyle"
   gem "rake"
   gem "rspec", "~> 3.0"
 end

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license      = "Apache-2.0"
 
   s.files        = %w{LICENSE} + Dir.glob("lib/**/*")
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.add_dependency "fog-aws", ">= 1", "< 4"
   s.add_dependency "knife-windows", "~> 1.0"

--- a/lib/knife-ec2/version.rb
+++ b/lib/knife-ec2/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Ec2
-    VERSION = "0.19.17".freeze
+    VERSION = "1.0.0".freeze
     MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end


### PR DESCRIPTION
### Description
This PR is only to prepare for major version release or `knife-ec2`.

TODO: task after acceptance of PR is need to remove `knife-windows` and support bootstrapping of windows node directly from chef infra.