### PR TITLE
Rename Ec2Base#connection to Ec2Base#ec2_connection

### DIFF
--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -73,7 +73,7 @@ class Chef
         output_column_count = server_list.length
         begin
           owner = locate_config_value(:owner) || "aws-marketplace"
-          servers = connection.describe_images({ "Owner" => "#{owner}" }) # aws-marketplace, microsoft
+          servers = ec2_connection.describe_images({ "Owner" => "#{owner}" }) # aws-marketplace, microsoft
         rescue Exception => api_error
           raise api_error
         end

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -80,7 +80,7 @@ class Chef
       end
 
       # @return [Fog::Compute]
-      def connection
+      def ec2_connection
         connection_settings = {
           provider: "AWS",
           region: locate_config_value(:region),
@@ -112,7 +112,7 @@ class Chef
 
       # @return [Boolean]
       def is_image_windows?
-        image_info = connection.images.get(@server.image_id)
+        image_info = ec2_connection.images.get(@server.image_id)
         image_info.platform == "windows"
       end
 

--- a/lib/chef/knife/ec2_flavor_list.rb
+++ b/lib/chef/knife/ec2_flavor_list.rb
@@ -42,7 +42,7 @@ class Chef
         output_column_count = flavor_list.length
 
         begin
-          flavors = connection.flavors.sort_by(&:id)
+          flavors = ec2_connection.flavors.sort_by(&:id)
         rescue Exception => api_error
           raise api_error
         end

--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -71,13 +71,13 @@ class Chef
         @name_args.each do |instance_id|
 
           begin
-            @server = connection.servers.get(instance_id)
+            @server = ec2_connection.servers.get(instance_id)
 
             msg_pair("Instance ID", @server.id)
             msg_pair("Instance Name", @server.tags["Name"])
             msg_pair("Flavor", @server.flavor_id)
             msg_pair("Image", @server.image_id)
-            msg_pair("Region", connection.instance_variable_get(:@region))
+            msg_pair("Region", ec2_connection.instance_variable_get(:@region))
             msg_pair("Availability Zone", @server.availability_zone)
             msg_pair("Security Groups", @server.groups.join(", "))
             msg_pair("IAM Profile", iam_name_from_profile(@server.iam_instance_profile)) if @server.iam_instance_profile

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -104,7 +104,7 @@ class Chef
           ui.warn "No region was specified in knife.rb/config.rb or as an argument. The default region, us-east-1, will be used:"
         end
 
-        servers = connection.servers
+        servers = ec2_connection.servers
         if config[:format] == "summary"
           servers.each do |server|
             server_list << server.id.to_s


### PR DESCRIPTION
### Description

There is a conflict of connection method while we are going to inherit the class Chef::Knife::Bootstrap class into Ec2ServerCreate both having connection method one for aws connection came from module Ec2Base another for bootstrap node connection from the train.

Any other suggestion would be helpful?

### Issues Resolved

https://github.com/chef/knife-ec2/issues/582