### PR TITLE
Added ec2_api_host option, to override for China regions

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -70,6 +70,11 @@ class Chef
             description: "Your AWS region",
             proc: Proc.new { |key| Chef::Config[:knife][:region] = key }
 
+          option :ec2_api_host,
+            long: "--ec2-api-host HOST",
+            description: "AWS ec2 API host",
+            proc: Proc.new { |key| Chef::Config[:knife][:ec2_api_host] = key }
+
           option :use_iam_profile,
             long: "--use-iam-profile",
             description: "Use IAM profile assigned to current machine",
@@ -86,6 +91,9 @@ class Chef
           region: locate_config_value(:region),
         }
 
+        unless locate_config_value(:ec2_api_host).nil? || locate_config_value(:ec2_api_host).empty?
+	  connection_settings[:host] = locate_config_value(:ec2_api_host)
+        end
         if locate_config_value(:use_iam_profile)
           connection_settings[:use_iam_profile] = true
         else


### PR DESCRIPTION
Added option `ec2_api_host` to be read from client knife.rb, which in turn sets the `host` attribute for `Fog::Compute`.
As Amazon documentation states in:
[https://docs.aws.amazon.com/general/latest/gr/rande.html](https://docs.aws.amazon.com/general/latest/gr/rande.html)
chinese regions _ec2.cn-north-1.amazonaws.com.cn_ and _ec2.cn-northwest-1.amazonaws.com.cn_ have domains *.cn, and currently specifying only the regions parameter ends up in:
`ERROR: Excon::Error::Socket: getaddrinfo: Name or service not known (SocketError)`
Adding:
`knife[:ec2_api_host]            = "ec2.cn-northwest-1.amazonaws.com.cn"`
will solve the issue.