### PR TITLE
Remove deprecated options & set default value for ec2 ami list owner option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,4 +38,4 @@ task :console do
   IRB.start
 end
 
-task default: [:style, :spec]
+task default: %i{style spec}

--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -68,7 +68,7 @@ class Chef
           ui.color("Architecture", :bold),
           ui.color("Size", :bold),
           ui.color("Name", :bold),
-          ui.color("Description", :bold)
+          ui.color("Description", :bold),
         ].flatten.compact
 
         output_column_count = servers_list.length

--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -43,13 +43,14 @@ class Chef
       option :platform,
         short: "-p PLATFORM",
         long: "--platform PLATFORM",
-        description: "Platform of the server. Allowed values are windows, ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco, amazon, nessus"
-
+        description: "Platform of the server",
+        in: Chef::Knife::Ec2Base::VALID_PLATFORMS
       option :owner,
         short: "-o OWNER",
         long: "--owner OWNER",
-        description: "The AMI owner (self, aws-marketplace, microsoft). Default is aws-marketplace",
-        default: "aws-marketplace"
+        description: "The AMI owner. Default is aws-marketplace",
+        default: "aws-marketplace",
+        in: %w{self aws-marketplace microsoft}
 
       option :search,
         short: "-s SEARCH",

--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -48,7 +48,8 @@ class Chef
       option :owner,
         short: "-o OWNER",
         long: "--owner OWNER",
-        description: "The AMI owner (self, aws-marketplace, microsoft). Default is aws-marketplace"
+        description: "The AMI owner (self, aws-marketplace, microsoft). Default is aws-marketplace",
+        default: "aws-marketplace"
 
       option :search,
         short: "-s SEARCH",
@@ -110,8 +111,7 @@ class Chef
 
       def image_params
         params = {}
-        owner = locate_config_value(:owner) || "aws-marketplace" # aws-marketplace, microsoft
-        params["owners"] = [owner.to_s]
+        params["owners"] = [locate_config_value(:owner).to_s]
 
         filters = []
         filters << { platform: locate_config_value(:platform) } if locate_config_value(:platform)

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -98,7 +98,7 @@ class Chef
       end
 
       def fetch_ami(image_id)
-        return {} unless image_id
+        return nil unless image_id
 
         ec2_connection.describe_images({
           image_ids: [image_id],
@@ -192,7 +192,7 @@ class Chef
       # Platform value return for Windows AMIs; otherwise, it is blank.
       # @return [Boolean]
       def is_image_windows?
-        ami.platform == "windows"
+        ami && ami.platform == "windows"
       end
 
       # validate the config options that were passed since some of them cannot be used together

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -21,6 +21,8 @@ require "chef/knife"
 class Chef
   class Knife
     module Ec2Base
+      # All valid platforms
+      VALID_PLATFORMS ||= %w{windows ubuntu debian centos fedora rhel nginx turnkey jumpbox coreos cisco amazon nessus}.freeze
 
       # @todo Would prefer to do this in a rational way, but can't be done b/c of Mixlib::CLI's design :(
       def self.included(includer)
@@ -165,7 +167,7 @@ class Chef
 
       # @return [Struct]
       def normalize_server_data(server_hashes)
-        require "ostruct"
+        require "ostruct" unless defined?(OpenStruct)
         OpenStruct.new(server_hashes)
       end
 
@@ -228,20 +230,7 @@ class Chef
             exit 1
           end
         end
-
-        if locate_config_value(:platform)
-          unless valid_platforms.include? (locate_config_value(:platform))
-            raise ArgumentError, "Invalid platform: #{locate_config_value(:platform)}. Allowed platforms are: #{valid_platforms.join(", ")}."
-          end
-        end
-
-        if locate_config_value(:owner)
-          unless %w{self aws-marketplace microsoft}.include? (locate_config_value(:owner))
-            raise ArgumentError, "Invalid owner: #{locate_config_value(:owner)}. Allowed owners are self, aws-marketplace or microsoft."
-          end
-        end
       end
-
     end
 
     # the path to the aws credentials file.
@@ -286,16 +275,10 @@ class Chef
       map
     end
 
-    # All valid platforms
-    # @return [Array]
-    def valid_platforms
-      %w{windows ubuntu debian centos fedora rhel nginx turnkey jumpbox coreos cisco amazon nessus}
-    end
-
     # Get the platform from server name
     # @return [String]
     def find_server_platform(server_name)
-      get_platform = valid_platforms.select { |name| server_name.downcase.include?(name) }
+      get_platform = VALID_PLATFORMS.select { |name| server_name.downcase.include?(name) }
       get_platform.first
     end
 

--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -236,7 +236,7 @@ class Chef
         end
 
         if locate_config_value(:owner)
-          unless ["self", "aws-marketplace", "microsoft"].include? (locate_config_value(:owner)) # rubocop:disable Style/WordArray
+          unless %w{self aws-marketplace microsoft}.include? (locate_config_value(:owner))
             raise ArgumentError, "Invalid owner: #{locate_config_value(:owner)}. Allowed owners are self, aws-marketplace or microsoft."
           end
         end

--- a/lib/chef/knife/ec2_eip_list.rb
+++ b/lib/chef/knife/ec2_eip_list.rb
@@ -38,7 +38,7 @@ class Chef
           ui.color("Private IPs", :bold),
           ui.color("IPv6 IPs", :bold),
           ui.color("Subnet ID", :bold),
-          ui.color("VPC ID", :bold)
+          ui.color("VPC ID", :bold),
         ].flatten.compact
 
         output_column_count = eni_list.length

--- a/lib/chef/knife/ec2_securitygroup_list.rb
+++ b/lib/chef/knife/ec2_securitygroup_list.rb
@@ -33,7 +33,7 @@ class Chef
         sg_list = [
           ui.color("ID", :bold),
           ui.color("Name", :bold),
-          ui.color("VPC ID", :bold)
+          ui.color("VPC ID", :bold),
         ].flatten.compact
 
         output_column_count = sg_list.length

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -543,7 +543,7 @@ class Chef
         # If --chef-tag is provided then it will be set in chef as single value e.g. --chef-tag "myTag"
         # --tags has been removed from knife-ec2, now it's available in core
         if config_value(:chef_tag)
-          config[:tags] = config_value(:tags) + config_value(:chef_tag)
+          config[:tags] += config_value(:chef_tag)
         end
         # Modify global configuration state to ensure hint gets set by
         # knife-bootstrap

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -714,6 +714,10 @@ class Chef
             raise "The input provided is incorrect."
           end
         end
+
+        if config_value(:chef_tag)
+          ui.warn("[DEPRECATED] --chef-tag option is deprecated and will be removed in future release. Use --tags TAGS option instead.")
+        end
       end
 
       def tags

--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -150,8 +150,8 @@ class Chef
 
           server_data["name"] = i.instances[0].tags[0].value
           server_data["az"] = i.instances[0].placement.availability_zone
-          server_data["iam_instance_profile"] = ( i.instances[0].iam_instance_profile.nil? ? nil : i.instances[0].iam_instance_profile.arn[/instance-profile\/(.*)/] )
-          server_data["security_groups"] = i.instances[0].security_groups.map { |x| x.group_name }.join(", ")
+          server_data["iam_instance_profile"] = ( i.instances[0].iam_instance_profile.nil? ? nil : i.instances[0].iam_instance_profile.arn[%r{instance-profile/(.*)}] )
+          server_data["security_groups"] = i.instances[0].security_groups.map(&:group_name).join(", ")
 
           all_data << server_data
         end
@@ -161,6 +161,7 @@ class Chef
       # Delete the server instance
       def delete_instance(instance_id)
         return nil unless instance_id || instance_id.is_a?(String)
+
         ec2_connection.terminate_instances({
           instance_ids: [
             instance_id,

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -117,7 +117,7 @@ class Chef
             ui.color("IAM Profile", :bold)
           end,
 
-          ui.color("State", :bold)
+          ui.color("State", :bold),
         ].flatten.compact
 
         output_column_count = servers_list.length
@@ -173,7 +173,7 @@ class Chef
             server_data["az"] = ui.color(i.instances[0].placement.availability_zone, azcolor(i.instances[0].placement.availability_zone))
           end
 
-          server_data["iam_instance_profile"] = ( i.instances[0].iam_instance_profile.nil? ? nil : i.instances[0].iam_instance_profile.arn[/instance-profile\/(.*)/] )
+          server_data["iam_instance_profile"] = ( i.instances[0].iam_instance_profile.nil? ? nil : i.instances[0].iam_instance_profile.arn[%r{instance-profile/(.*)}] )
 
           server_data["state"] = ui.color(i.instances[0].state.name, state_color(i.instances[0].state.name))
 
@@ -182,7 +182,7 @@ class Chef
           end
 
           # dig into security_groups struct
-          server_data["security_groups"] = i.instances[0].security_groups.map { |x| x.group_name }
+          server_data["security_groups"] = i.instances[0].security_groups.map(&:group_name)
 
           all_data << server_data
         end
@@ -191,7 +191,7 @@ class Chef
 
       # @return [Array<String>]
       def extract_tags(tags_struct)
-        tags_struct.map { |x| x.value }
+        tags_struct.map(&:value)
       end
     end
   end

--- a/lib/chef/knife/ec2_subnet_list.rb
+++ b/lib/chef/knife/ec2_subnet_list.rb
@@ -38,7 +38,7 @@ class Chef
           ui.color("Available IPs", :bold),
           ui.color("AZ Default?", :bold),
           ui.color("Maps Public IP?", :bold),
-          ui.color("VPC ID", :bold)
+          ui.color("VPC ID", :bold),
         ].flatten.compact
 
         output_column_count = subnet_list.length

--- a/lib/chef/knife/ec2_vpc_list.rb
+++ b/lib/chef/knife/ec2_vpc_list.rb
@@ -36,7 +36,7 @@ class Chef
           ui.color("CIDR Block", :bold),
           ui.color("Instance Tenancy", :bold),
           ui.color("DHCP Options ID", :bold),
-          ui.color("Default VPC?", :bold)
+          ui.color("Default VPC?", :bold),
         ].flatten.compact
 
         output_column_count = vpcs_list.length

--- a/lib/chef/knife/s3_source.rb
+++ b/lib/chef/knife/s3_source.rb
@@ -52,9 +52,9 @@ class Chef
       def path
         uri = URI(@url)
         if uri.scheme == "s3"
-          URI(@url).path.sub(/^\//, "")
+          URI(@url).path.sub(%r{^/}, "")
         else
-          URI(@url).path.split(bucket).last.sub(/^\//, "")
+          URI(@url).path.split(bucket).last.sub(%r{^/}, "")
         end
       end
 

--- a/spec/unit/ec2_ami_list_spec.rb
+++ b/spec/unit/ec2_ami_list_spec.rb
@@ -141,9 +141,8 @@ describe Chef::Knife::Ec2AmiList do
 
       context "When owner is invalid" do
         it "raises error" do
-          knife_ec2_ami_list.config[:owner] = "xyz"
-          knife_ec2_ami_list.config[:use_iam_profile] = true
-          expect { knife_ec2_ami_list.validate_aws_config! }.to raise_error "Invalid owner: #{knife_ec2_ami_list.config[:owner]}. Allowed owners are self, aws-marketplace or microsoft."
+          allow(knife_ec2_ami_list).to receive(:puts)
+          expect(lambda { knife_ec2_ami_list.parse_options(["--owner", "xyz"]) }).to raise_error(SystemExit)
         end
       end
     end
@@ -234,10 +233,8 @@ describe Chef::Knife::Ec2AmiList do
 
       context "When platform is invalid" do
         it "raises error" do
-          knife_ec2_ami_list.config[:platform] = "xyz"
-          knife_ec2_ami_list.config[:use_iam_profile] = true
-          knife_ec2_ami_list.config[:owner] = true
-          expect { knife_ec2_ami_list.validate_aws_config! }.to raise_error "Invalid platform: #{knife_ec2_ami_list.config[:platform]}. Allowed platforms are: windows, ubuntu, debian, centos, fedora, rhel, nginx, turnkey, jumpbox, coreos, cisco, amazon, nessus."
+          allow(knife_ec2_ami_list).to receive(:puts)
+          expect(lambda { knife_ec2_ami_list.parse_options(["--platform", "xyz"]) }).to raise_error(SystemExit)
         end
       end
     end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -124,7 +124,8 @@ describe Chef::Knife::Ec2ServerCreate do
       private_ip_address: "10.251.75.20",
       root_device_type: "ebs",
       block_device_mapping: [{ volume_id: 456 }],
-      volume_id: "v-006eub006") end
+      volume_id: "v-006eub006")
+  end
 
   let(:my_vpc) { "vpc-12345678" }
 
@@ -156,7 +157,7 @@ describe Chef::Knife::Ec2ServerCreate do
     allow(ec2_connection).to receive(:subnets).and_return [@subnet_1, @subnet_2]
     allow(ec2_connection).to receive_message_chain(:network_interfaces, :all).and_return [
       double("network_interfaces", network_interface_id: "eni-12345678"),
-      double("network_interfaces", network_interface_id: "eni-87654321")
+      double("network_interfaces", network_interface_id: "eni-87654321"),
     ]
 
     {
@@ -902,14 +903,14 @@ describe Chef::Knife::Ec2ServerCreate do
 
       it "reads UNIX Line endings for new format" do
         allow(File).to receive(:read)
-         .and_return("[default]\nregion=#{@region}")
+          .and_return("[default]\nregion=#{@region}")
         knife_ec2_create.validate_aws_config!
         expect(Chef::Config[:knife][:region]).to eq(@region)
       end
 
       it "reads DOS Line endings for new format" do
         allow(File).to receive(:read)
-         .and_return("[default]\nregion=#{@region}")
+          .and_return("[default]\nregion=#{@region}")
         knife_ec2_create.validate_aws_config!
         expect(Chef::Config[:knife][:region]).to eq(@region)
       end
@@ -955,12 +956,12 @@ describe Chef::Knife::Ec2ServerCreate do
 
     it "returns a path to a tmp file when presented with a URI for the " \
       "validation key" do
-      Chef::Config[:knife][:validation_key_url] = @validation_key_url
+        Chef::Config[:knife][:validation_key_url] = @validation_key_url
 
-      allow(knife_ec2_create).to receive_message_chain(:validation_key_tmpfile, :path).and_return(@validation_key_file)
+        allow(knife_ec2_create).to receive_message_chain(:validation_key_tmpfile, :path).and_return(@validation_key_file)
 
-      expect(knife_ec2_create.validation_key_path).to eq(@validation_key_file)
-    end
+        expect(knife_ec2_create.validation_key_path).to eq(@validation_key_file)
+      end
 
     it "disallows security group names when using a VPC" do
       knife_ec2_create.config[:subnet_id] = @subnet_1_id
@@ -987,7 +988,7 @@ describe Chef::Knife::Ec2ServerCreate do
 
       allow(ec2_connection).to receive_message_chain(:network_interfaces, :all).and_return [
         double("network_interfaces", network_interface_id: "eni-12345678", vpc_id: "another_vpc"),
-        double("network_interfaces", network_interface_id: "eni-87654321", vpc_id: my_vpc)
+        double("network_interfaces", network_interface_id: "eni-87654321", vpc_id: my_vpc),
       ]
 
       expect { knife_ec2_create.plugin_validate_options! }.to raise_error SystemExit

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -431,31 +431,6 @@ describe Chef::Knife::Ec2ServerCreate do
       expect(knife_ec2_create).to receive(:plugin_validate_options!)
       knife_ec2_create.run
     end
-
-    it "sets the Name tag to the specified name when given --tags Name=NAME" do
-      knife_ec2_create.config[:tags] = ["Name=bobcat"]
-      tags_params = { tags: [ key: "Name", value: "bobcat"], resources: [ec2_server_attribs.id] }
-      expect(ec2_connection).to receive(:create_tags).with(tags_params)
-      expect(knife_ec2_create).to receive(:plugin_validate_options!)
-      knife_ec2_create.run
-    end
-
-    it "sets arbitrary tags" do
-      knife_ec2_create.config[:tags] = ["foo=bar"]
-      tags_params = { tags: [ { key: "foo", value: "bar" }, { key: "Name", value: "i-00fe186450a2e8e97" }], resources: [ec2_server_attribs.id] }
-      expect(ec2_connection).to receive(:create_tags).with(tags_params)
-      expect(knife_ec2_create).to receive(:plugin_validate_options!)
-      knife_ec2_create.run
-    end
-
-    it 'raises deprecated warning "[DEPRECATED] --tags option is deprecated. Use --aws-tag option instead."' do
-      knife_ec2_create.config[:tags] = ["foo=bar"]
-      tags_params = { tags: [ { key: "foo", value: "bar" }, { key: "Name", value: "i-00fe186450a2e8e97" }], resources: [ec2_server_attribs.id] }
-      expect(ec2_connection).to receive(:create_tags).with(tags_params)
-      expect(knife_ec2_create.ui).to receive(:warn).with("[DEPRECATED] --tags option is deprecated. Use --aws-tag option instead.").exactly(2).times
-      knife_ec2_create.plugin_validate_options!
-      knife_ec2_create.run
-    end
   end
 
   describe "when setting volume tags" do
@@ -2482,51 +2457,6 @@ describe Chef::Knife::Ec2ServerCreate do
     end
   end
 
-  describe "--security-group-ids option" do
-    before do
-      allow(ec2_server_create).to receive(:validate_aws_config!)
-      allow(ec2_server_create).to receive(:validate_nics!)
-      allow(ec2_server_create).to receive(:ami).and_return(ami)
-      allow(knife_ec2_create).to receive(:msg_pair)
-      allow(knife_ec2_create).to receive(:puts)
-      allow(knife_ec2_create).to receive(:print)
-    end
-
-    context "when comma seprated values are provided from cli" do
-      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["--security-group-ids", "sg-aabbccdd,sg-3764sdss,sg-00aa11bb"]) }
-      it "creates array of security group ids" do
-        server_def = ec2_server_create.server_attributes
-        expect(server_def[:security_group_ids]).to eq(["sg-aabbccdd", "sg-3764sdss", "sg-00aa11bb"]) # rubocop:disable Style/WordArray
-      end
-    end
-
-    context "when mulitple values provided from cli for e.g. --security-group-ids sg-aab343ytr --security-group-ids sg-3764sdss" do
-      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["--security-group-ids", "sg-aab343ytr", "--security-group-ids", "sg-3764sdss"]) } # rubocop:disable Style/WordArray
-      it "creates array of security group ids" do
-        allow(ec2_server_create.ui).to receive(:warn)
-        server_def = ec2_server_create.server_attributes
-        expect(server_def[:security_group_ids]).to eq(["sg-aab343ytr", "sg-3764sdss"]) # rubocop:disable Style/WordArray
-      end
-    end
-
-    context "when comma seprated input is provided from knife.rb" do
-      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new }
-      it "raises error" do
-        Chef::Config[:knife][:security_group_ids] = "sg-aabbccdd, sg-3764sdss, sg-00aa11bb"
-        expect(ec2_server_create.ui).to receive(:error).with("Invalid value type for knife[:security_group_ids] in knife configuration file (i.e knife.rb/config.rb). Type should be array. e.g - knife[:security_group_ids] = ['sgroup1']")
-        expect { ec2_server_create.plugin_validate_options! }.to raise_error(SystemExit)
-      end
-    end
-
-    context "when security group ids array is provided from knife.rb" do
-      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new }
-      it "allows --security-group-ids set from an array in knife.rb" do
-        Chef::Config[:knife][:security_group_ids] = ["sg-aabbccdd", "sg-3764sdss", "sg-00aa11bb"] # rubocop:disable Style/WordArray
-        expect { ec2_server_create.plugin_validate_options! }.to_not raise_error(SystemExit)
-      end
-    end
-  end
-
   describe "--security-group-id option" do
     before do
       allow(ec2_server_create).to receive(:validate_aws_config!)
@@ -2593,19 +2523,6 @@ describe Chef::Knife::Ec2ServerCreate do
       it "creates array of aws tag" do
         server_def = ec2_server_create.config
         expect(server_def[:aws_tag]).to eq(["foo=bar"])
-      end
-    end
-  end
-
-  describe "--tag-node-in-chef option" do
-    context "when provided from cli for e.g. --tag-node-in-chef" do
-      let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["--tag-node-in-chef"]) }
-      it 'raises deprecated warning "[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead."' do
-        allow(ec2_server_create).to receive(:validate_aws_config!)
-        allow(ec2_server_create).to receive(:validate_nics!)
-        allow(ec2_server_create).to receive(:ami).and_return(ami)
-        expect(ec2_server_create.ui).to receive(:warn).with("[DEPRECATED] --tag-node-in-chef option is deprecated. Use --chef-tag option instead.")
-        ec2_server_create.plugin_validate_options!
       end
     end
   end

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -165,7 +165,7 @@ describe Chef::Knife::Ec2ServerCreate do
       ssh_key_name: "ssh_key_name",
       connection_user: "user",
       connection_password: "password",
-      network_interfaces: ["eni-12345678", "eni-87654321"], # rubocop:disable Style/WordArray
+      network_interfaces: %w{eni-12345678 eni-87654321},
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end
@@ -2468,7 +2468,7 @@ describe Chef::Knife::Ec2ServerCreate do
       let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["-g", "sg-aab343ytr", "-g", "sg-3764sdss"]) }
       it "creates array of security group ids" do
         server_def = ec2_server_create.server_attributes
-        expect(server_def[:security_group_ids]).to eq(["sg-aab343ytr", "sg-3764sdss"]) # rubocop:disable Style/WordArray
+        expect(server_def[:security_group_ids]).to eq(%w{sg-aab343ytr sg-3764sdss})
       end
     end
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2485,6 +2485,9 @@ describe Chef::Knife::Ec2ServerCreate do
       allow(ec2_server_create).to receive(:validate_aws_config!)
       allow(ec2_server_create).to receive(:validate_nics!)
       allow(ec2_server_create).to receive(:ami).and_return(ami)
+      ec2_server_create.config[:tags] = []
+      expect(ec2_server_create.ui).to receive(:warn).with("[DEPRECATED] --chef-tag option is deprecated and will be removed in future release. Use --tags TAGS option instead.")
+      ec2_server_create.plugin_validate_options!
     end
     context 'when mulitple values provided from cli for e.g. --chef-tag "foo" --chef-tag "bar"' do
       let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["--chef-tag", "foo", "--chef-tag", "bar"]) }


### PR DESCRIPTION
### Description

 - Removed options `--tag-node-in-chef` and `--security-group-ids`
 - As `--tags` also deprecated but available in chef-core so `--tags` removed from knife-ec2.
 - Currently `--tags` and `--chef-tag` do the same things so we can also deprecated `--chef-tag` from knife-ec2 plugin?


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG