### PR TITLE
Add connection debug information

### DIFF
--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -887,7 +887,7 @@ describe Chef::Knife::Ec2ServerCreate do
         it "raises exception" do
           Chef::Config[:knife][:aws_profile] = "xyz"
           allow(File).to receive(:read).and_return("[default]\naws_access_key_id=TESTKEY\r\naws_secret_access_key=TESTSECRET")
-          expect { knife_ec2_create.validate_aws_config! }.to raise_error("The provided --aws-profile 'xyz' is invalid.")
+          expect { knife_ec2_create.validate_aws_config! }.to raise_error("The provided --aws-profile 'xyz' is invalid. Does the credential file at '/apple/pear' contain this profile?")
         end
       end
 


### PR DESCRIPTION
I was having a really hard time getting this plugin to work on my
system. I thought I could run the plugin in debug, but that didn't
provide any connection information. I added debug statements to various
parts of the connection setup and I improved the error when the aws
profile is missing from your credentials file, which is what my error
actually was. This will result in secret keys being written to the
terminal, but there isn't really a way around that when someone runs a
cloud plugin in debug.

Signed-off-by: Tim Smith <tsmith@chef.io>