### PR TITLE
Attach emphemeral disks with using --emphemeral flag & avoid tagging error

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -949,7 +949,7 @@ class Chef
         if config[:ephemeral] && config[:ephemeral].length > 0
           ephemeral_blocks = []
           config[:ephemeral].each_with_index do |device_name, i|
-            ephemeral_blocks << { virtual_name: "ephemeral#{i}", device_name: device_name }
+            ephemeral_blocks << { virtual_name: "ephemeral#{i}", device_name: device_name, ebs: { volume_size: ebs_size } }
           end
           attributes[:block_device_mappings] += ephemeral_blocks
         end

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -958,7 +958,6 @@ class Chef
         attributes[:disable_api_termination] = config_value(:disable_api_termination) if config_value(:spot_price).nil?
 
         attributes[:instance_initiated_shutdown_behavior] = config_value(:instance_initiated_shutdown_behavior)
-        attributes[:chef_tag] = config_value(:tags)
         attributes
       end
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -1161,10 +1161,10 @@ describe Chef::Knife::Ec2ServerCreate do
       knife_ec2_create.config[:ephemeral] = [ "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde" ]
       server_def = knife_ec2_create.server_attributes
       expect(server_def[:block_device_mappings]).to eq([{ device_name: nil, ebs: { delete_on_termination: nil, iops: "123", volume_size: "30", volume_type: nil } },
-                                                   { virtual_name: "ephemeral0", device_name: "/dev/sdb", :ebs=>{:volume_size=>"30"} },
-                                                   { virtual_name: "ephemeral1", device_name: "/dev/sdc", :ebs=>{:volume_size=>"30"} },
-                                                   { virtual_name: "ephemeral2", device_name: "/dev/sdd", :ebs=>{:volume_size=>"30"} },
-                                                   { virtual_name: "ephemeral3", device_name: "/dev/sde", :ebs=>{:volume_size=>"30"} }])
+                                                   { virtual_name: "ephemeral0", device_name: "/dev/sdb", ebs: { volume_size: "30" } },
+                                                   { virtual_name: "ephemeral1", device_name: "/dev/sdc", ebs: { volume_size: "30" } },
+                                                   { virtual_name: "ephemeral2", device_name: "/dev/sdd", ebs: { volume_size: "30" } },
+                                                   { virtual_name: "ephemeral3", device_name: "/dev/sde", ebs: { volume_size: "30" } }])
     end
 
     it "sets the specified private ip address" do

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -1161,10 +1161,10 @@ describe Chef::Knife::Ec2ServerCreate do
       knife_ec2_create.config[:ephemeral] = [ "/dev/sdb", "/dev/sdc", "/dev/sdd", "/dev/sde" ]
       server_def = knife_ec2_create.server_attributes
       expect(server_def[:block_device_mappings]).to eq([{ device_name: nil, ebs: { delete_on_termination: nil, iops: "123", volume_size: "30", volume_type: nil } },
-                                                    { virtual_name: "ephemeral0", device_name: "/dev/sdb" },
-                                                   { virtual_name: "ephemeral1", device_name: "/dev/sdc" },
-                                                   { virtual_name: "ephemeral2", device_name: "/dev/sdd" },
-                                                   { virtual_name: "ephemeral3", device_name: "/dev/sde" }])
+                                                   { virtual_name: "ephemeral0", device_name: "/dev/sdb", :ebs=>{:volume_size=>"30"} },
+                                                   { virtual_name: "ephemeral1", device_name: "/dev/sdc", :ebs=>{:volume_size=>"30"} },
+                                                   { virtual_name: "ephemeral2", device_name: "/dev/sdd", :ebs=>{:volume_size=>"30"} },
+                                                   { virtual_name: "ephemeral3", device_name: "/dev/sde", :ebs=>{:volume_size=>"30"} }])
     end
 
     it "sets the specified private ip address" do

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -2493,16 +2493,14 @@ describe Chef::Knife::Ec2ServerCreate do
     context 'when mulitple values provided from cli for e.g. --chef-tag "foo" --chef-tag "bar"' do
       let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["--chef-tag", "foo", "--chef-tag", "bar"]) }
       it "creates array of chef tag" do
-        server_def = ec2_server_create.server_attributes
-        expect(server_def[:chef_tag]).to eq(%w{foo bar})
+        expect(ec2_server_create.config[:tags]).to eq(%w{foo bar})
       end
     end
 
     context "when single value provided from cli for e.g. --chef-tag foo" do
       let(:ec2_server_create) { Chef::Knife::Ec2ServerCreate.new(["--chef-tag", "foo"]) }
       it "creates array of chef tag" do
-        server_def = ec2_server_create.server_attributes
-        expect(server_def[:chef_tag]).to eq(["foo"])
+        expect(ec2_server_create.config[:tags]).to eq(["foo"])
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

- This fix sets the ephemeral devices to AWS console.
- Also fixed `ERROR: unexpected value at params[:chef_tag]`


### Issues Resolved

Fixes https://github.com/chef/knife-ec2/issues/590

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG