### PR TITLE
Add --cpu-credits option for launching T2/T3 instances as unlimited

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -726,11 +726,9 @@ class Chef
           ui.warn("[DEPRECATED] --chef-tag option is deprecated and will be removed in future release. Use --tags TAGS option instead.")
         end
 
-        if config_value(:cpu_credits)
-          if !config_value(:flavor)
-            ui.error("Instance type should be specified and should be any of T2/T3 type.")
-            exit 1
-          end
+        if config_value(:cpu_credits) && !config_value(:flavor)
+          ui.error("Instance type should be specified and should be any of T2/T3 type.")
+          exit 1
         end
       end
 
@@ -974,9 +972,9 @@ class Chef
         attributes[:instance_initiated_shutdown_behavior] = config_value(:instance_initiated_shutdown_behavior)
 
         attributes[:credit_specification] =
-         {
-           cpu_credits: config[:cpu_credits]
-         }
+          {
+            cpu_credits: config[:cpu_credits],
+          }
         attributes
       end
 

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -1110,6 +1110,25 @@ describe Chef::Knife::Ec2ServerCreate do
         expect { knife_ec2_create.plugin_validate_options! }.to raise_error SystemExit
       end
     end
+
+    context "when cpu_credits option is specified" do
+      it "raise error on missing flavor" do
+        knife_ec2_create.config[:cpu_credits] = "unlimited"
+        expect { knife_ec2_create.plugin_validate_options! }.to raise_error SystemExit
+      end
+
+      it "raise error when invalid string is passed other than 'unlimited' and 'standard'" do
+        knife_ec2_create.config[:cpu_credits] = "xyz"
+        knife_ec2_create.config[:flavor] = "t2.medium"
+        expect { knife_ec2_create.plugin_validate_options! }.to raise_error SystemExit
+      end
+
+      it "raise error on flavor type other than T2/T3" do
+        knife_ec2_create.config[:cpu_credits] = "unlimited"
+        knife_ec2_create.config[:flavor] = "m3.medium"
+        expect { knife_ec2_create.plugin_validate_options! }.to raise_error SystemExit
+      end
+    end
   end
 
   describe "when creating the server definition" do

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -1238,6 +1238,20 @@ describe Chef::Knife::Ec2ServerCreate do
       expect(server_def[:type]).to eq("one-time")
     end
 
+    it "sets cpu credit as unlimited for T2 instance" do
+      knife_ec2_create.config[:cpu_credits] = "unlimited"
+      knife_ec2_create.config[:flavor] = "t2.micro"
+      server_def = knife_ec2_create.server_attributes
+      expect(server_def[:credit_specification][:cpu_credits]).to eq("unlimited")
+    end
+
+    it "sets cpu credit as standard for T3 instance" do
+      knife_ec2_create.config[:cpu_credits] = "standard"
+      knife_ec2_create.config[:flavor] = "t3.micro"
+      server_def = knife_ec2_create.server_attributes
+      expect(server_def[:credit_specification][:cpu_credits]).to eq("standard")
+    end
+
     context "when using ebs volume type and ebs provisioned iops rate options" do
       before do
         allow(knife_ec2_create).to receive(:ami).and_return(ami)


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

- `--cpu-credits` option added
- Validation added

### Issues Resolved
Fixes https://github.com/chef/knife-ec2/issues/519

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG