### PR TITLE
Fix argument error for --platform option

### DIFF
--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -115,7 +115,10 @@ class Chef
         params["owners"] = [locate_config_value(:owner).to_s]
 
         filters = []
-        filters << { platform: locate_config_value(:platform) } if locate_config_value(:platform)
+        if locate_config_value(:platform)
+          filters << { name: "platform",
+                       values: [locate_config_value(:platform)] }
+        end
 
         # TODO: Need to find substring to match in the description
         # filters << { description: locate_config_value(:search) } if locate_config_value(:search)


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description
- knife ec2 ami list --platform returns `ERROR: ArgumentError: unexpected value at params["filters"][0][:platform]`
- Handles the error by passing appropriate content to filter array


### Issues Resolved

Fixes https://github.com/chef/knife-ec2/issues/607

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG