### PR TITLE
Insert conditional to avoid error for non T2/T3 instance

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -278,7 +278,6 @@ class Chef
       option :cpu_credits,
         long: "--cpu-credits CPU_CREDITS",
         description: "The credit option for CPU usage of the instance. Valid values are standard and unlimited. T3 instances launch as unlimited by default. T2 instances launch as standard by default.",
-        default: "standard",
         in: %w{standard unlimited}
 
       def plugin_create_instance!
@@ -984,10 +983,12 @@ class Chef
 
         attributes[:instance_initiated_shutdown_behavior] = config_value(:instance_initiated_shutdown_behavior)
 
-        attributes[:credit_specification] =
-          {
-            cpu_credits: config[:cpu_credits],
-          }
+        if config[:cpu_credits]
+          attributes[:credit_specification] =
+            {
+              cpu_credits: config[:cpu_credits],
+            }
+        end
         attributes
       end
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

- Resolves `ERROR: The <flavor-type> instance type does not support T2 Unlimited.` if `--cpu-credits` is not provided for instance type other than T2/T3
### Issues Resolved

Fixes https://github.com/chef/knife-ec2/issues/615

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG