### PR TITLE
Fix missing credential error for aws-profile

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -328,7 +328,7 @@ class Chef
 
       aws_creds = ini_parse(File.read(aws_cred_file_location))
       profile = locate_config_value(:aws_profile)
-
+      profile = "profile #{profile}" if profile != "default"
       Chef::Log.debug "Using AWS profile #{profile}"
       entries = if aws_creds.values.first.key?("AWSAccessKeyId")
                   aws_creds.values.first

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -391,7 +391,7 @@ class Chef
           Chef::Config[:validation_key] = validation_key_path
         end
 
-        config[:connection_protocol] ||= connection_protocol
+        config[:connection_protocol] ||= connection_protocol_ec2
         config[:connection_port] ||= connection_port
 
         # Check if Server is Windows or Linux
@@ -1369,7 +1369,7 @@ class Chef
 
       # TODO: connection_protocol and connection_port used to choose winrm/ssh or 5985/22 based on the image chosen
       def connection_port
-        port = config_value(:connection_port, knife_key_for_protocol(connection_protocol, :port))
+        port = config_value(:connection_port, knife_key_for_protocol(connection_protocol_ec2, :port))
         return port if port
 
         assign_default_port
@@ -1388,15 +1388,15 @@ class Chef
 
       # url values override CLI flags, if you provide both
       # we'll use the one that you gave in the URL.
-      def connection_protocol
-        return @connection_protocol if @connection_protocol
+      def connection_protocol_ec2
+        return @connection_protocol_ec2 if @connection_protocol_ec2
 
         default_protocol = is_image_windows? ? "winrm" : "ssh"
 
         from_url = host_descriptor =~ %r{^(.*)://} ? $1 : nil
         from_cli = config[:connection_protocol]
         from_knife = Chef::Config[:knife][:connection_protocol]
-        @connection_protocol = from_url || from_cli || from_knife || default_protocol
+        @connection_protocol_ec2 = from_url || from_cli || from_knife || default_protocol
       end
 
       def connection_user

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1400,7 +1400,7 @@ class Chef
       end
 
       def connection_user
-        @connection_user ||= config_value(:connection_user, knife_key_for_protocol(connection_protocol, :user))
+        @connection_user ||= config_value(:connection_user, knife_key_for_protocol(connection_protocol_ec2, :user))
       end
 
       def server_name

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -140,7 +140,6 @@ describe Chef::Knife::Ec2ServerCreate do
     allow(knife_ec2_create).to receive(:plugin_finalize)
     allow(knife_ec2_create).to receive(:ec2_connection).and_return ec2_connection
     allow(knife_ec2_create).to receive(:tcp_test_ssh)
-    allow(knife_ec2_create).to receive(:wait_for_sshd)
     allow(knife_ec2_create).to receive(:msg_pair)
     allow(knife_ec2_create).to receive(:puts)
     allow(knife_ec2_create).to receive(:print)
@@ -206,6 +205,7 @@ describe Chef::Knife::Ec2ServerCreate do
       allow(knife_ec2_create).to receive(:print)
       allow(knife_ec2_create.ui).to receive(:color).and_return("")
       allow(knife_ec2_create).to receive(:confirm)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
     end
 
     it "creates a new spot instance request with request type as persistent" do
@@ -310,6 +310,7 @@ describe Chef::Knife::Ec2ServerCreate do
   describe "run" do
     before do
       expect(knife_ec2_create).to receive(:plugin_validate_options!)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
       allow(knife_ec2_create).to receive(:ami).and_return(ami)
       allow(knife_ec2_create).to receive(:server_attributes).and_return(server_attributes)
       expect(ec2_connection).to receive(:run_instances).with(server_attributes).and_return(server_instances)
@@ -391,6 +392,7 @@ describe Chef::Knife::Ec2ServerCreate do
   describe "when setting tags" do
     before do
       allow(knife_ec2_create).to receive(:validate_aws_config!)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
       allow(knife_ec2_create).to receive(:validate_nics!)
       allow(knife_ec2_create).to receive(:ami).and_return(ami)
       allow(knife_ec2_create).to receive(:server_attributes).and_return(server_attributes)
@@ -438,6 +440,7 @@ describe Chef::Knife::Ec2ServerCreate do
   describe "when setting volume tags" do
     before do
       allow(knife_ec2_create).to receive(:validate_aws_config!)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
       allow(knife_ec2_create).to receive(:validate_nics!)
       allow(knife_ec2_create).to receive(:ami).and_return(ami)
       allow(knife_ec2_create).to receive(:server_attributes).and_return(server_attributes)
@@ -721,6 +724,7 @@ describe Chef::Knife::Ec2ServerCreate do
     before do
       allow(knife_ec2_create).to receive(:ami).and_return(ami)
       allow(knife_ec2_create).to receive(:validate_aws_config!)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
       allow(knife_ec2_create).to receive(:validate_nics!).and_return(true)
       allow(knife_ec2_create).to receive(:server_attributes).and_return(server_attributes)
       expect(ec2_connection).to receive(:run_instances).with(server_attributes).and_return(server_instances)
@@ -778,6 +782,7 @@ describe Chef::Knife::Ec2ServerCreate do
       knife_ec2_create.config[:fqdn] = "ec2-75.101.253.10.compute-1.amazonaws.com"
 
       allow(knife_ec2_create).to receive(:validate_aws_config!)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
       allow(knife_ec2_create).to receive(:validate_nics!)
       allow(knife_ec2_create).to receive(:ami).and_return(ami)
       allow(knife_ec2_create).to receive(:server_attributes).and_return(server_attributes)
@@ -2568,6 +2573,7 @@ describe Chef::Knife::Ec2ServerCreate do
   describe "disable_source_dest_check option" do
     before do
       expect(knife_ec2_create).to receive(:plugin_validate_options!)
+      allow(knife_ec2_create).to receive(:wait_for_sshd)
       allow(knife_ec2_create).to receive(:ami).and_return(ami)
       allow(knife_ec2_create).to receive(:server_attributes).and_return(server_attributes)
       expect(ec2_connection).to receive(:run_instances).with(server_attributes).and_return(server_instances)

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -59,9 +59,9 @@ describe Chef::Knife::Ec2ServerCreate do
     OpenStruct.new(
       architecture: "x86_64",
       image_id: "ami-005bdb005fb00e791",
-      platform: "windows",
+      platform: "ubuntu",
       name: "image-test",
-      description: "test windows winrm image",
+      description: "test ubuntu image",
       root_device_type: "ebs",
       block_device_mappings: [block_device_mappings]
     )
@@ -140,6 +140,7 @@ describe Chef::Knife::Ec2ServerCreate do
     allow(knife_ec2_create).to receive(:plugin_finalize)
     allow(knife_ec2_create).to receive(:ec2_connection).and_return ec2_connection
     allow(knife_ec2_create).to receive(:tcp_test_ssh)
+    allow(knife_ec2_create).to receive(:wait_for_sshd)
     allow(knife_ec2_create).to receive(:msg_pair)
     allow(knife_ec2_create).to receive(:puts)
     allow(knife_ec2_create).to receive(:print)
@@ -903,7 +904,7 @@ describe Chef::Knife::Ec2ServerCreate do
       it "loads the correct profile" do
         Chef::Config[:knife][:aws_profile] = "other"
         allow(File).to receive(:read)
-          .and_return("[default]\naws_access_key_id=TESTKEY\r\naws_secret_access_key=TESTSECRET\n\n[other]\naws_access_key_id=#{@access_key_id}\r\naws_secret_access_key=#{@secret_key}")
+          .and_return("[default]\naws_access_key_id=TESTKEY\r\naws_secret_access_key=TESTSECRET\n\n[profile other]\naws_access_key_id=#{@access_key_id}\r\naws_secret_access_key=#{@secret_key}")
         knife_ec2_create.validate_aws_config!
         expect(Chef::Config[:knife][:aws_access_key_id]).to eq(@access_key_id)
         expect(Chef::Config[:knife][:aws_secret_access_key]).to eq(@secret_key)
@@ -913,7 +914,7 @@ describe Chef::Knife::Ec2ServerCreate do
         it "raises exception" do
           Chef::Config[:knife][:aws_profile] = "xyz"
           allow(File).to receive(:read).and_return("[default]\naws_access_key_id=TESTKEY\r\naws_secret_access_key=TESTSECRET")
-          expect { knife_ec2_create.validate_aws_config! }.to raise_error("The provided --aws-profile 'xyz' is invalid. Does the credential file at '/apple/pear' contain this profile?")
+          expect { knife_ec2_create.validate_aws_config! }.to raise_error("The provided --aws-profile 'profile xyz' is invalid. Does the credential file at '/apple/pear' contain this profile?")
         end
       end
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

- During `ec2 server create` we were getting `unable to sign request without credentials set` error for specified `aws-profile` in `aws_credential_file`.
- Method `connection_protocol` was named same in ec2 as well as in chef so previously `validate_protocol` method was calling `connection_protocol` from chef rather than from ec2 and this resulted into nil credentials.
- Renaming `connection_protocol` method helps invoking method from ec2 and fixes the issue.

### Issues Resolved

Fixes https://github.com/chef/knife-ec2/issues/617

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG