### PR TITLE
Mask AWS access keys data from logs

### DIFF
--- a/lib/chef/knife/ec2_base.rb
+++ b/lib/chef/knife/ec2_base.rb
@@ -88,7 +88,8 @@ class Chef
             Chef::Log.debug "Using iam profile for authentication as use_iam_profile set"
             Aws::InstanceProfileCredentials.new
           else
-            Chef::Log.debug "Setting up AWS connection using aws_access_key_id #{locate_config_value(:aws_access_key_id)} aws_secret_access_key: #{locate_config_value(:aws_secret_access_key)} aws_session_token: #{locate_config_value(:aws_session_token)}"
+            Chef::Log.debug "Setting up AWS connection using aws_access_key_id: #{mask(locate_config_value(:aws_access_key_id))} aws_secret_access_key: #{mask(locate_config_value(:aws_secret_access_key))} aws_session_token: #{mask(locate_config_value(:aws_session_token))}"
+
             Aws::Credentials.new(locate_config_value(:aws_access_key_id), locate_config_value(:aws_secret_access_key), locate_config_value(:aws_session_token))
           end
         conn
@@ -342,6 +343,17 @@ class Chef
       else
         raise ArgumentError, "The provided --aws-profile '#{profile}' is invalid. Does the credential file at '#{aws_cred_file_location}' contain this profile?"
       end
+    end
+
+    # Mask the given string with char `X`
+    # Discard the chars based on from value
+    def mask(key, from = 4)
+      str = key.dup
+      if str && str.length > from
+        str[from...str.length] = "X" * (str[from...str.length].length)
+      end
+
+      str
     end
   end
 end


### PR DESCRIPTION
### Description
Before Fix:

```
=> bundle exec knife ec2 server list -VV
INFO: Using configuration from /home/ad.msystechnologies.com/vivek.singh/projects/chef-workstation/.chef/config.rb
DEBUG: Using AWS region us-west-2
DEBUG: Setting up AWS connection using aws_access_key_id: AKIABCDEFGHIJKLMNOPQ aws_secret_access_key: cLPeABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890 aws_session_token:
```

After Fix:

```
=> bundle exec knife ec2 server list -VV
INFO: Using configuration from /home/ad.msystechnologies.com/vivek.singh/projects/chef-workstation/.chef/config.rb
DEBUG: Using AWS region us-west-2
DEBUG: Setting up AWS connection using aws_access_key_id: AKIAXXXXXXXXXXXXXXXX aws_secret_access_key: cLPeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX aws_session_token:
```

### Issues Resolved

Closes https://github.com/chef/knife-ec2/issues/612

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
