### PR TITLE
Fix ssh_gateway uninitialised error

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -31,6 +31,7 @@ class Chef
         require "tempfile"
         require "uri"
         require "net/ssh"
+        require "net/ssh/gateway"
         Chef::Knife::Bootstrap.load_deps
       end
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description
- When we create a new server but use the `--ssh-gateway` parameter, it seems knife segfaults when waiting for the EC2 server to come alive with an error of `Exception: NameError: uninitialized constant Net::SSH::Gateway`
- We've handled this issue using `require net/ssh/gateway`


### Issues Resolved

Closes https://github.com/chef/knife-ec2/issues/618

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG