### PR TITLE
Fix for invalid format of auto generated keypair file name

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1177,7 +1177,7 @@ class Chef
       end
 
       def create_key_pair
-        key_name = "#{config[:connection_user]}-#{SecureRandom.hex(10)}"
+        key_name = "#{config[:connection_user].delete(".\\")}-#{SecureRandom.hex(10)}"
         key_pair = ec2_connection.create_key_pair({
           key_name: key_name,
         })


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- Fix for the invalid format of the auto-generated keypair file name
- Added test cases
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes: #624 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG