### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/ec2_ami_list.rb
+++ b/lib/chef/knife/ec2_ami_list.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_eip_list.rb
+++ b/lib/chef/knife/ec2_eip_list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_flavor_list.rb
+++ b/lib/chef/knife/ec2_flavor_list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_securitygroup_list.rb
+++ b/lib/chef/knife/ec2_securitygroup_list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
-require "chef/knife/s3_source"
+require_relative "ec2_base"
+require_relative "s3_source"
 require "chef/knife/bootstrap"
 
 class Chef

--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_subnet_list.rb
+++ b/lib/chef/knife/ec2_subnet_list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/ec2_vpc_list.rb
+++ b/lib/chef/knife/ec2_vpc_list.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "chef/knife/ec2_base"
+require_relative "ec2_base"
 
 class Chef
   class Knife


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>