### PR TITLE
Set connection_protocol and connection_port as default before the create instance

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -392,9 +392,6 @@ class Chef
           Chef::Config[:validation_key] = validation_key_path
         end
 
-        config[:connection_protocol] ||= connection_protocol_ec2
-        config[:connection_port] ||= connection_port
-
         # Check if Server is Windows or Linux
         if is_image_windows?
           if winrm?
@@ -574,6 +571,13 @@ class Chef
         # Amazon Virtual Private Cloud requires a subnet_id. If
         # present, do a few things differently
         !!config_value(:subnet_id)
+      end
+
+      # When options connection_protocol and connection_port are not provided
+      # It will set as default
+      def plugin_setup!
+        config[:connection_protocol] ||= connection_protocol_ec2
+        config[:connection_port] ||= connection_port
       end
 
       def validate_name_args!


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- Added `plugin_setup!` method
- When options `connection_protocol` and `connection_port` are not provided then It will set as default
- Ensured chef-style on the code changes made

### Issues Resolved
Fixed: #627 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG