### PR TITLE
Fix for Aws MissingCredentialsError

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -576,6 +576,7 @@ class Chef
       # When options connection_protocol and connection_port are not provided
       # It will set as default
       def plugin_setup!
+        validate_aws_config!(%i{image aws_access_key_id aws_secret_access_key})
         config[:connection_protocol] ||= connection_protocol_ec2
         config[:connection_port] ||= connection_port
       end
@@ -591,8 +592,6 @@ class Chef
           ui.warn("Use of aws_ssh_key_id option in knife.rb/config.rb config is deprecated, use ssh_key_name option instead.")
         end
         create_key_pair unless config_value(:ssh_key_name)
-
-        validate_aws_config!(%i{image ssh_key_name aws_access_key_id aws_secret_access_key})
 
         validate_nics! if config_value(:network_interfaces)
 
@@ -1397,7 +1396,6 @@ class Chef
         return @connection_protocol_ec2 if @connection_protocol_ec2
 
         default_protocol = is_image_windows? ? "winrm" : "ssh"
-
         from_url = host_descriptor =~ %r{^(.*)://} ? $1 : nil
         from_cli = config[:connection_protocol]
         from_knife = Chef::Config[:knife][:connection_protocol]

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -166,6 +166,8 @@ describe Chef::Knife::Ec2ServerCreate do
       connection_user: "user",
       connection_password: "Password@123",
       network_interfaces: %w{eni-12345678 eni-87654321},
+      aws_access_key_id: "ABCDEFGHIJKLMNOPQR",
+      aws_secret_access_key: "aBcDEFghi64HKLmin789kldjKj123",
     }.each do |key, value|
       Chef::Config[:knife][key] = value
     end


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- In the `plugin_setup!` we are calling `connection_protocol_ec2` method, so at this time it initialize `Aws::EC2::Client` before reading  aws `credentials` file, so `aws_access_key_id` and `aws_secret_access_key` values are not available at this time, so I have fixed it.
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes: #632 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG