### PR TITLE
Fix for Train SSH Connection Error

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -1409,7 +1409,13 @@ class Chef
       def server_name
         return nil unless server
 
-        server.public_dns_name || server.private_dns_name || server.private_ip_address
+        if !server.public_dns_name.empty?
+          server.public_dns_name
+        elsif !server.private_dns_name.empty?
+          server.private_dns_name
+        else
+          server.private_ip_address
+        end
       end
 
       alias host_descriptor server_name

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -366,6 +366,23 @@ describe Chef::Knife::Ec2ServerCreate do
       expect(File).to receive(:open).with(@validation_key_file, "w")
       knife_ec2_create.run
     end
+
+    context "when server public_dns_name returns a blank string" do
+      it "return a private_dns_name" do
+        allow(ec2_server_attribs).to receive(:public_dns_name).and_return("")
+        knife_ec2_create.run
+        expect(knife_ec2_create.server_name).to eql("ip-10-251-75-20.ec2.internal")
+      end
+    end
+
+    context "when server public_dns_name and private_dns_name both returns a blank string" do
+      it "return a private_ip_address" do
+        allow(ec2_server_attribs).to receive(:public_dns_name).and_return("")
+        allow(ec2_server_attribs).to receive(:private_dns_name).and_return("")
+        knife_ec2_create.run
+        expect(knife_ec2_create.server_name).to eql("10.251.75.20")
+      end
+    end
   end
 
   describe "run for EC2 Windows instance" do


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- When `server.public_dns_name` returns a blank string "",  it tries to connect as a host, so due to this, it raises an error `ERROR: Train::ClientError: You must provide a value for "host".`. So I have fixed it by adding conditions.
- Added test cases
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes: #633 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG