### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."

--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -28,9 +28,9 @@ class Chef
       include Knife::Ec2Base
 
       deps do
-        require "tempfile"
-        require "uri"
-        require "net/ssh"
+        require "tempfile" unless defined?(Tempfile)
+        require "uri" unless defined?(URI)
+        require "net/ssh" unless defined?(Net::SSH)
         require "net/ssh/gateway"
         Chef::Knife::Bootstrap.load_deps
       end
@@ -826,7 +826,7 @@ class Chef
 
       # base64-encoded text
       def encode_data(text)
-        require "base64"
+        require "base64" unless defined?(Base64)
         Base64.encode64(text)
       end
 
@@ -1321,8 +1321,8 @@ class Chef
       end
 
       def decrypt_admin_password(encoded_password, key)
-        require "base64"
-        require "openssl"
+        require "base64" unless defined?(Base64)
+        require "openssl" unless defined?(OpenSSL)
         private_key = OpenSSL::PKey::RSA.new(key)
         encrypted_password = Base64.decode64(encoded_password)
         private_key.private_decrypt(encrypted_password)

--- a/spec/unit/ec2_server_create_spec.rb
+++ b/spec/unit/ec2_server_create_spec.rb
@@ -1895,7 +1895,7 @@ describe Chef::Knife::Ec2ServerCreate do
   end
 
   describe "attach ssl config into user data when transport is ssl" do
-    require "base64"
+    require "base64" unless defined?(Base64)
 
     before(:each) do
       allow(knife_ec2_create).to receive(:validate_aws_config!)


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>