### PR TITLE
Fix for Knife-ec2 server list doesn't show instance name

### DIFF
--- a/lib/chef/knife/ec2_server_delete.rb
+++ b/lib/chef/knife/ec2_server_delete.rb
@@ -148,7 +148,7 @@ class Chef
             server_data[id] = i.instances[0].send(id)
           end
 
-          server_data["name"] = i.instances[0].tags[0].value
+          server_data["name"] = find_name_tag(i.instances[0].tags)
           server_data["az"] = i.instances[0].placement.availability_zone
           server_data["iam_instance_profile"] = ( i.instances[0].iam_instance_profile.nil? ? nil : i.instances[0].iam_instance_profile.arn[%r{instance-profile/(.*)}] )
           server_data["security_groups"] = i.instances[0].security_groups.map(&:group_name).join(", ")

--- a/lib/chef/knife/ec2_server_list.rb
+++ b/lib/chef/knife/ec2_server_list.rb
@@ -166,7 +166,7 @@ class Chef
           tags = extract_tags(i.instances[0].tags)
 
           if config[:name]
-            server_data["name"] = tags[0]
+            server_data["name"] = find_name_tag(i.instances[0].tags)
           end
 
           if config[:az]

--- a/lib/chef/knife/helpers/ec2_base.rb
+++ b/lib/chef/knife/helpers/ec2_base.rb
@@ -151,7 +151,7 @@ class Chef
         server_data["id"] = server_data["instance_id"]
 
         tags = server_obj.instances[0].tags.map(&:value)
-        server_data["name"] = tags[0]
+        server_data["name"] = find_name_tag(server_obj.instances[0].tags)
         server_data["placement_group"] = server_obj.instances[0].placement.group_name
         server_data["security_groups"] = server_obj.instances[0].security_groups.map(&:group_name)
         server_data["security_group_ids"] = server_obj.instances[0].security_groups.map(&:group_id)
@@ -179,6 +179,13 @@ class Chef
 
       def ami
         @ami ||= fetch_ami(config[:image])
+      end
+
+      # Name tag value return.
+      # @return [String]
+      def find_name_tag(tags)
+        name_tag = tags.find { |tag| tag[:key] == "Name" }
+        name_tag ? name_tag[:value] : nil
       end
 
       # Platform value return for Windows AMIs; otherwise, it is blank.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
- Now Knife-ec2 server list show instance name
- Added test cases
- Ensured chefstyle on the code changes made

## Output
```
msys@PUN-LAP-KAPIL-C:~/workspace/knife-ec2$ bundle exec knife ec2 server list --region us-east-2 -c /home/msys/workspace/assignment_2/.chef/knife.rb
Instance ID          Name                         Public IP       Private IP     Flavor      Image                  SSH Key                   Security Groups                                                                      State
i-0859dc3ef6c652565  kchouhan-red-8                               IP_ADDRESS   t2.micro    ami-03d64741867e7bb94  kchouhan                  launch-wizard-85                                                                     stopped
i-0b3fc2e3d524394b3  kchouhan-windows             IP_ADDRESS      IP_ADDRESS  t2.micro    ami-00133f78ad56a5c91  kchouhan                  launch-wizard-63                                                                     running
i-0132edf11f3d63b21  kchouhan-7.8                                 IP_ADDRESS  t2.large    ami-08de027b0238b586e  kchouhan                  Red Hat Enterprise Linux Server 7-8 -Maipo--RHEL-7-8-20200506-10GiB-AutogenByAWSMP-  stopped
```
## Related Issue
Fixes: #662 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
