### PR TITLE
S3Source does not extend any Chef classes, so config is not an inherited attribute

### DIFF
--- a/lib/chef/knife/ec2_server_create.rb
+++ b/lib/chef/knife/ec2_server_create.rb
@@ -522,7 +522,7 @@ class Chef
 
       def s3_validation_key
         @s3_validation_key ||= begin
-          Chef::Knife::S3Source.fetch(config[:validation_key_url])
+          Chef::Knife::S3Source.fetch(config[:validation_key_url], config)
         end
       end
 
@@ -530,7 +530,7 @@ class Chef
         @s3_secret ||= begin
           return false unless config[:s3_secret]
 
-          Chef::Knife::S3Source.fetch(config[:s3_secret])
+          Chef::Knife::S3Source.fetch(config[:s3_secret], config)
         end
       end
 

--- a/lib/chef/knife/helpers/s3_source.rb
+++ b/lib/chef/knife/helpers/s3_source.rb
@@ -17,11 +17,12 @@
 class Chef
   class Knife
     class S3Source
-      attr_accessor :url
+      attr_accessor :url, :config
 
-      def self.fetch(url)
+      def self.fetch(url, config)
         source = Chef::Knife::S3Source.new
         source.url = url
+        source.config = config
         source.body
       end
 

--- a/spec/unit/s3_source_deps_spec.rb
+++ b/spec/unit/s3_source_deps_spec.rb
@@ -14,20 +14,22 @@ describe "Check Dependencies", exclude: Object.constants.include?(:Aws) do
 
   it "lazy loads Aws::S3::Client without required config" do
     begin
-      Chef::Knife::S3Source.fetch("test")
+      knife_config = {}
+      Chef::Knife::S3Source.fetch("test", knife_config)
     rescue Exception => e
-      expect(e).to be_a_kind_of(NoMethodError)
+      expect(e).to be_a_kind_of(ArgumentError)
     end
   end
 
   it "lazy loads Aws::S3::Client with required config" do
     begin
-      Chef::Config[:knife][:aws_access_key_id] = "aws_access_key_id"
-      Chef::Config[:knife][:aws_secret_access_key] = "aws_secret_access_key"
-      Chef::Config[:knife][:region] = "test-region"
-      Chef::Knife::S3Source.fetch("test")
+      knife_config = {}
+      knife_config[:aws_access_key_id] = "aws_access_key_id"
+      knife_config[:aws_secret_access_key] = "aws_secret_access_key"
+      knife_config[:region] = "test-region"
+      Chef::Knife::S3Source.fetch("/test/testfile", knife_config)
     rescue Exception => e
-      expect(e).to be_a_kind_of(ArgumentError)
+      expect(e).to be_a_kind_of(Aws::Errors::NoSuchEndpointError)
     end
   end
 end


### PR DESCRIPTION
S3Source does not extend any Chef classes, so config is not an inherited attribute and as such needs to be passed in to fetch() explicitly

## Description
All calls to S3Source.fetch were failing because none of the AWS access information was available using config attribute.  (Modified in 2cc491d74)

Also fixes rspec tests for S3Source which have been broken and untested for... a long time.  At least since 2cc491d74, but it appears much longer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
