### PR TITLE
Support for ruby3.4

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -14,7 +14,19 @@ steps:
 - label: run-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
+  env:
+    CHEF_LICENSE: accept-no-persist
   expeditor:
     executor:
       docker:
         image: ruby:3.1-buster
+
+- label: run-specs-ruby-3.4
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  env:
+    CHEF_LICENSE: accept-no-persist
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.4

--- a/knife-ec2.gemspec
+++ b/knife-ec2.gemspec
@@ -18,5 +18,12 @@ Gem::Specification.new do |s|
   s.add_dependency "aws-sdk-s3", "~> 1.43"
   s.add_dependency "aws-sdk-ec2", "~> 1.95"
 
+  # These gems were removed from Ruby standard library from version 3.4
+  # See: https://stdgems.org/new-in/3.4
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
+    s.add_dependency "abbrev", "~> 0.1"
+    s.add_dependency "syslog", "~> 0.3"
+  end
+
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
* Add conditional gem dependencies for Ruby 3.4 compatibility
* Include syslog and abbrev gems when running on Ruby 3.4+
* These gems were removed from Ruby standard library in 3.4
  See: https://stdgems.org/new-in/3.4


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
